### PR TITLE
ci: add workflow permissions and concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Add explicit read-only permissions and concurrency controls to the CI workflow to follow least-privilege security practices and avoid redundant runs.

## Summary

Harden the LS Panel CI workflow by defining explicit permissions and concurrency behavior.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Build / CI
- [ ] Other

## Related issue

N/A

## Changes

- Add explicit read-only workflow permissions
- Apply the principle of least privilege to GitHub Actions
- Add concurrency handling for CI runs
- Cancel superseded in-progress runs
- Address CodeQL workflow permission findings

## Testing

The workflow configuration will be validated by GitHub Actions after the pull request is created.

## Screenshots

Not applicable.

## Checklist

- [x] I have reviewed my own changes.
- [x] The code follows the existing project style.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where necessary.
- [x] My changes do not introduce new warnings or errors.
- [x] I have not included sensitive information, credentials, or private data.