### PR TITLE
Prepare v0.5.1-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1-beta] - 2026-08-10
+
 ### Changed
 
 - Restyled the Databases list to match the Sites page: a card-wrapped table with a database icon per row, denser stacked columns (usage, status, admin client), and clickable rows that open the database instead of requiring the separate "Edit" button.
@@ -164,7 +166,8 @@ Initial public beta.
 - Bilingual UI and documentation (English / Ukrainian).
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/bewdes/LSPanel/compare/v0.5.0-beta...HEAD
+[Unreleased]: https://github.com/bewdes/LSPanel/compare/v0.5.1-beta...HEAD
+[0.5.1-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.5.1-beta
 [0.5.0-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.5.0-beta
 [0.4.0-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.4.0-beta
 [0.3.1-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.3.1-beta

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 > 🇺🇦 Українська версія цього документа: [README.uk.md](README.uk.md)
 
 [![CI](https://github.com/bewdes/LSPanel/actions/workflows/ci.yml/badge.svg)](https://github.com/bewdes/LSPanel/actions/workflows/ci.yml)
-![Version](https://img.shields.io/badge/version-0.5.0--beta-orange)
+![Version](https://img.shields.io/badge/version-0.5.1--beta-orange)
 ![Rust](https://img.shields.io/badge/backend-Rust-b7410e)
 ![React](https://img.shields.io/badge/frontend-React_19-61dafb)
 ![Tauri](https://img.shields.io/badge/shell-Tauri_2-24c8db)
@@ -21,7 +21,7 @@
 ![Linux](https://img.shields.io/badge/platform-Linux-fcc624)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-> ⚠️ **Status: v0.5.0-beta.** LS Panel is in active early development — expect breaking changes and rough edges.
+> ⚠️ **Status: v0.5.1-beta.** LS Panel is in active early development — expect breaking changes and rough edges.
 
 ## Why LS Panel?
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -12,7 +12,7 @@
 > 🇬🇧 English version of this document: [README.md](README.md)
 
 [![CI](https://github.com/bewdes/LSPanel/actions/workflows/ci.yml/badge.svg)](https://github.com/bewdes/LSPanel/actions/workflows/ci.yml)
-![Version](https://img.shields.io/badge/version-0.5.0--beta-orange)
+![Version](https://img.shields.io/badge/version-0.5.1--beta-orange)
 ![Rust](https://img.shields.io/badge/backend-Rust-b7410e)
 ![React](https://img.shields.io/badge/frontend-React_19-61dafb)
 ![Tauri](https://img.shields.io/badge/shell-Tauri_2-24c8db)
@@ -21,7 +21,7 @@
 ![Linux](https://img.shields.io/badge/platform-Linux-fcc624)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-> ⚠️ **Статус: v0.5.0-beta.** LS Panel перебуває на ранній стадії активної розробки — можливі суттєві зміни та шорсткі кути.
+> ⚠️ **Статус: v0.5.1-beta.** LS Panel перебуває на ранній стадії активної розробки — можливі суттєві зміни та шорсткі кути.
 
 ## Чому LS Panel?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lspanel",
   "private": true,
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1978,7 +1978,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lspanel"
-version = "0.5.0-beta"
+version = "0.5.1-beta"
 dependencies = [
  "portable-pty",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lspanel"
-version = "0.5.0-beta"
+version = "0.5.1-beta"
 description = "Local server control panel"
 license = "Apache-2.0"
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LS Panel",
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "identifier": "dev.lspanel.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Version bump 0.5.0-beta → 0.5.1-beta (patch — this batch is fixes/security only, no Added entries) and CHANGELOG finalization for the accumulated Tier 1/2 audit fixes already on master: secret redaction, webhook host restriction, SQLite file permissions, MySQL/MariaDB password exposure, snapshot-restore trust bug, LiveLink config race, orphaned files on env deletion, Xdebug/Apache detection, TLS cert generation locking, and UX gating fixes.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (153 passed)
- [x] `node scripts/check-version-sync.mjs` — versions in sync across package.json/tauri.conf.json/Cargo.toml
- [x] `npx prettier --check .`, `npx eslint . --max-warnings 0`, `npx tsc --noEmit`, `npm run test:frontend` (8 passed)
- [x] `npm run build`