### PR TITLE
Add an About section to Settings with version and contact info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Settings: an "About" section showing the app version, description, and author contact links (GitHub profile, repository, email).
+
 ## [0.5.1-beta] - 2026-08-10
 
 ### Changed

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,3 +1,5 @@
+import * as React from "react"
+import { getVersion } from "@tauri-apps/api/app"
 import {
   Blocks,
   ArchiveRestore,
@@ -58,6 +60,10 @@ export function AppSidebar({
   onOpenSearch: () => void
 }) {
   const text = pickLanguage(language).appSidebar
+  const [appVersion, setAppVersion] = React.useState("")
+  React.useEffect(() => {
+    void getVersion().then(setAppVersion)
+  }, [])
   const primary = [
     { id: "dashboard" as const, label: text.dashboard, icon: LayoutDashboard },
     { id: "sites" as const, label: text.sites, icon: Server },
@@ -98,9 +104,11 @@ export function AppSidebar({
               <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
                 <span className="flex items-center gap-1.5 truncate font-semibold">
                   LS Panel
-                  <span className="truncate text-[10px] font-normal text-muted-foreground">
-                    Beta v. 0.1.0
-                  </span>
+                  {appVersion && (
+                    <span className="truncate text-[10px] font-normal text-muted-foreground">
+                      Beta v.{appVersion}
+                    </span>
+                  )}
                 </span>
                 <span className="truncate text-xs text-muted-foreground">Local development</span>
               </div>

--- a/src/features/settings/settings-page.tsx
+++ b/src/features/settings/settings-page.tsx
@@ -1,15 +1,22 @@
 import * as React from "react"
+import { getVersion } from "@tauri-apps/api/app"
 import { invoke } from "@tauri-apps/api/core"
 import { open as openDialog } from "@tauri-apps/plugin-dialog"
 import {
   BellRing,
+  BookOpen,
   Container,
+  ExternalLink,
   FolderCog,
   Folder,
   Gauge,
+  GitBranch,
+  Info,
   LayoutPanelLeft,
   Layers,
+  Mail,
   Save,
+  Server,
   SlidersHorizontal,
 } from "lucide-react"
 
@@ -33,7 +40,14 @@ import { applyTheme } from "@/theme"
 import { DATABASE_VERSIONS, PHP_VERSIONS, defaultDatabaseVersion } from "@/lib/version-catalog"
 
 type Section =
-  "general" | "workspace" | "docker" | "projects" | "monitoring" | "interface" | "performance"
+  | "general"
+  | "workspace"
+  | "docker"
+  | "projects"
+  | "monitoring"
+  | "interface"
+  | "performance"
+  | "about"
 
 export function SettingsPage({
   settings,
@@ -45,7 +59,12 @@ export function SettingsPage({
   const [draft, setDraft] = React.useState(settings)
   const [status, setStatus] = React.useState("")
   const [section, setSection] = React.useState<Section>("general")
+  const [appVersion, setAppVersion] = React.useState("")
   const text = pickLanguage(draft.language).settings
+
+  React.useEffect(() => {
+    void getVersion().then(setAppVersion)
+  }, [])
 
   const sections: { id: Section; label: string; icon: typeof SlidersHorizontal }[] = [
     { id: "general", label: text.navGeneral, icon: SlidersHorizontal },
@@ -55,6 +74,7 @@ export function SettingsPage({
     { id: "monitoring", label: text.navMonitoring, icon: BellRing },
     { id: "interface", label: text.navInterface, icon: LayoutPanelLeft },
     { id: "performance", label: text.navPerformance, icon: Gauge },
+    { id: "about", label: text.navAbout, icon: Info },
   ]
 
   async function chooseDirectory() {
@@ -636,6 +656,61 @@ export function SettingsPage({
                   />
                 </Field>
                 <p className="text-xs text-muted-foreground">{text.statsRefreshIntervalHint}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {section === "about" && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary text-primary-foreground">
+                    <Server className="size-5" />
+                  </div>
+                  <div>
+                    <CardTitle>LS Panel</CardTitle>
+                    {appVersion && (
+                      <CardDescription>{text.aboutVersion(appVersion)}</CardDescription>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="grid gap-5">
+                <p className="text-sm text-muted-foreground">{text.aboutDescription}</p>
+                <Separator />
+                <div className="grid gap-2">
+                  <Label>{text.aboutContactTitle}</Label>
+                  <Button
+                    variant="outline"
+                    className="justify-start gap-2"
+                    onClick={() => void invoke("open_url", { url: "https://github.com/bewdes" })}
+                  >
+                    <GitBranch className="size-4" />
+                    <span className="flex-1 text-left">github.com/bewdes</span>
+                    <ExternalLink className="size-4 text-muted-foreground" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="justify-start gap-2"
+                    onClick={() =>
+                      void invoke("open_url", { url: "https://github.com/bewdes/LSPanel" })
+                    }
+                  >
+                    <BookOpen className="size-4" />
+                    <span className="flex-1 text-left">github.com/bewdes/LSPanel</span>
+                    <ExternalLink className="size-4 text-muted-foreground" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="justify-start gap-2"
+                    onClick={() => {
+                      window.location.href = "mailto:bewdes.studio@gmail.com"
+                    }}
+                  >
+                    <Mail className="size-4" />
+                    <span className="flex-1 text-left">bewdes.studio@gmail.com</span>
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           )}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -940,6 +940,7 @@ const en = {
     navMonitoring: "Monitoring",
     navInterface: "Interface",
     navPerformance: "Performance",
+    navAbout: "About",
     generalCardDescription: "Language, theme, and safety confirmations.",
     languageLabel: "Language",
     confirmDestructiveTitle: "Confirm destructive actions",
@@ -1024,6 +1025,10 @@ const en = {
     performanceCardDescription: "How often LS Panel refreshes live data.",
     statsRefreshIntervalLabel: "Stats refresh interval (seconds)",
     statsRefreshIntervalHint: "How often the dashboard and project resource usage numbers update.",
+    aboutVersion: (version: string) => `Version ${version}`,
+    aboutDescription:
+      "A desktop local development environment manager for PHP/web projects, built with Tauri and React.",
+    aboutContactTitle: "Author & contact",
     saveChanges: "Save changes",
   },
   siteDetails: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -976,6 +976,7 @@ const uk: Dictionary = {
     navMonitoring: "Моніторинг",
     navInterface: "Інтерфейс",
     navPerformance: "Продуктивність",
+    navAbout: "Про застосунок",
     generalCardDescription: "Мова, тема та підтвердження небезпечних дій.",
     languageLabel: "Мова",
     confirmDestructiveTitle: "Підтверджувати руйнівні дії",
@@ -1062,6 +1063,10 @@ const uk: Dictionary = {
     statsRefreshIntervalLabel: "Інтервал оновлення статистики (секунд)",
     statsRefreshIntervalHint:
       "Як часто оновлюються показники дашборду та використання ресурсів проєктів.",
+    aboutVersion: (version: string) => `Версія ${version}`,
+    aboutDescription:
+      "Десктопний менеджер локального середовища розробки для PHP/веб-проєктів, створений на Tauri та React.",
+    aboutContactTitle: "Автор і контакти",
     saveChanges: "Зберегти зміни",
   },
   siteDetails: {


### PR DESCRIPTION
## Summary
- New "About" section in Settings (last nav item): app name, real version via Tauri's `getVersion()`, short description, and clickable contact links (GitHub profile, LSPanel repository, email).
- Fixed the sidebar header's hardcoded "Beta v. 0.1.0" (leftover from early development) to show the real version too.

## Test plan
- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx prettier --check .`
- [x] `npm run test:frontend` (8 passed, including the en/uk i18n key-parity test)
- [x] `npm run build`