### PR TITLE
Replace two frontend polling loops with backend-pushed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Settings: an "About" section showing the app version, description, and author contact links (GitHub profile, repository, email).
 
+### Fixed
+
+- Editing an environment from the separate Containers window no longer leaves the main window's environment list stale.
+
 ## [0.5.1-beta] - 2026-08-10
 
 ### Changed

--- a/src-tauri/src/administration_commands.rs
+++ b/src-tauri/src/administration_commands.rs
@@ -1,3 +1,5 @@
+use tauri::Emitter;
+
 #[tauri::command]
 pub fn export_environment_logs(
     app: tauri::AppHandle,
@@ -72,6 +74,7 @@ pub fn save_environment(
         &format!("Середовище «{name}» збережено"),
         &format!("Environment \"{name}\" saved"),
     );
+    let _ = app.emit("environments-changed", ());
     Ok(result)
 }
 
@@ -83,7 +86,10 @@ pub fn delete_environment(
     let operation = crate::operations::create(&app, Some(&id), "delete-environment")?;
     let result = crate::containers::delete(&app, &id);
     match &result {
-        Ok(_) => crate::operations::complete(&app, &operation.id)?,
+        Ok(_) => {
+            crate::operations::complete(&app, &operation.id)?;
+            let _ = app.emit("environments-changed", ());
+        }
         Err(error) => crate::operations::fail(&app, &operation.id, error)?,
     }
     result

--- a/src-tauri/src/livelink.rs
+++ b/src-tauri/src/livelink.rs
@@ -8,7 +8,7 @@ use std::{
     process::{Command, Stdio},
     sync::{LazyLock, Mutex},
 };
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 /// Serializes mutating access to the shared `livelink.json` config across
 /// `start()`/`stop()`. Without this, two near-simultaneous `start()` calls
@@ -444,6 +444,28 @@ pub fn status(app: &tauri::AppHandle) -> LiveLinkStatus {
             "Tailscale is ready".into()
         },
         links,
+    }
+}
+
+/// After `start()` returns for Tailscale, HTTPS serve can take a few more
+/// seconds to actually come up on Tailscale's backend. Rather than have the
+/// frontend poll `status()` on a timer, sample it here on the backend and
+/// push each change via the "livelink-status-changed" event. Bounded to
+/// ~60s and stops as soon as serve is enabled or the tunnel drops, so this
+/// never lingers as a permanent background task.
+pub fn watch_until_serve_enabled(app: &tauri::AppHandle) {
+    let mut previous: Option<(bool, bool)> = None;
+    for _ in 0..60 {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let current = status(app);
+        let signature = (current.connected, current.serve_enabled);
+        if previous != Some(signature) {
+            previous = Some(signature);
+            let _ = app.emit("livelink-status-changed", &current);
+        }
+        if current.serve_enabled || !current.connected {
+            return;
+        }
     }
 }
 

--- a/src-tauri/src/livelink_commands.rs
+++ b/src-tauri/src/livelink_commands.rs
@@ -16,6 +16,7 @@ pub async fn start_livelink(
     hostname: Option<String>,
 ) -> Result<LiveLinkStatus, AppError> {
     let worker = app.clone();
+    let provider_for_watch = provider.clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
         crate::livelink::start(&worker, &site_id, &mode, &provider, hostname.as_deref())
     })
@@ -28,6 +29,12 @@ pub async fn start_livelink(
         "LiveLink увімкнено",
         "LiveLink enabled",
     );
+    if provider_for_watch == "tailscale" && !result.serve_enabled {
+        let watcher = app.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            crate::livelink::watch_until_serve_enabled(&watcher)
+        });
+    }
     Ok(result)
 }
 

--- a/src-tauri/src/site_commands.rs
+++ b/src-tauri/src/site_commands.rs
@@ -2,6 +2,7 @@ use crate::{
     app_error, backups, containers, environment_files, notifications, operations,
     project_templates, security, settings, sites, storage,
 };
+use tauri::Emitter;
 
 #[tauri::command]
 pub fn list_sites(app: tauri::AppHandle) -> Result<Vec<sites::Site>, String> {
@@ -319,7 +320,10 @@ pub async fn create_project_environment(
     .map_err(|error| error.to_string())?;
     let result = result.map_err(|error| security::redact(&error, creation_secrets));
     match &result {
-        Ok(_) => operations::complete(&app, &operation_id)?,
+        Ok(_) => {
+            operations::complete(&app, &operation_id)?;
+            let _ = app.emit("environments-changed", ());
+        }
         Err(error) => operations::fail(&app, &operation_id, error)?,
     }
     app_error::AppError::operation_result(result, operation_id)

--- a/src/features/livelink/live-link-page.tsx
+++ b/src/features/livelink/live-link-page.tsx
@@ -230,9 +230,14 @@ export function LiveLinkPage({
 
   React.useEffect(() => {
     if (!status?.connected || status.serveEnabled) return
-    const timer = window.setInterval(() => void refresh(), 3000)
-    return () => window.clearInterval(timer)
-  }, [refresh, status?.connected, status?.serveEnabled])
+    // Tailscale Serve can take a few seconds to come up after start(); the
+    // backend samples status server-side and pushes each change here instead
+    // of the frontend polling on a timer.
+    const unlisten = listen<LiveLinkStatus>("livelink-status-changed", ({ payload }) =>
+      setStatus(payload),
+    )
+    return () => void unlisten.then((stop) => stop())
+  }, [status?.connected, status?.serveEnabled])
 
   const start = async () => {
     if (!siteId) return


### PR DESCRIPTION
## Summary

An ARCH-07 audit (every frontend `setInterval` cross-referenced against every backend `.emit()`) found no case of "an event already exists but nobody wires it up" — every backend-emitted event already has a frontend listener. Two narrower, more concrete things turned up instead:

- **Real bug**: `main.tsx:119` listens for `environments-changed`, which the backend never emits. `environment-window.tsx` is a separate OS-level Tauri window (the "Containers" window, `desktop_commands.rs`), so saving/deleting/creating an environment there had no way to tell the main window's list to refresh — it only worked for mutations made from the main window itself, which already call `refresh()` directly. Fixed by emitting `environments-changed` from `save_environment`, `delete_environment`, and `create_project_environment`.
- **LiveLink tunnel status** (`live-link-page.tsx`): replaced the 3s `setInterval` (active only while waiting for Tailscale Serve to come up after `start_livelink`) with a bounded backend watch loop (`livelink::watch_until_serve_enabled`, capped at ~60s, exits as soon as serve is enabled or the tunnel drops) that pushes a `livelink-status-changed` event on each state change instead.

The other 3 polling loops found (dashboard/sites resource stats, mail inbox) were left as-is — they're continuous external-state sampling (CPU/mem numbers, Mailpit's own container-internal HTTP API) with no natural "moment of change" to push from, so converting them would mean building genuinely new backend infrastructure rather than wiring up something that already exists.

## Test plan
- [x] `cargo fmt --all --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test` (153 passed) — all clean
- [x] `npx tsc --noEmit` / `npx eslint` / `npx prettier --check` on changed files — all clean
- [x] `npm run test:frontend` — 8/8 pass
- [x] `npm run build` — succeeds
