### PR TITLE
Let deleting an environment name its projects and skip file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Editing an environment from the separate Containers window no longer leaves the main window's environment list stale.
+- Deleting an environment now names the projects it will remove and lets you keep their files on disk instead of always deleting them unconditionally, matching the option already available when deleting a single project.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/administration_commands.rs
+++ b/src-tauri/src/administration_commands.rs
@@ -82,9 +82,10 @@ pub fn save_environment(
 pub fn delete_environment(
     app: tauri::AppHandle,
     id: String,
+    delete_files: bool,
 ) -> Result<Vec<crate::containers::Environment>, String> {
     let operation = crate::operations::create(&app, Some(&id), "delete-environment")?;
-    let result = crate::containers::delete(&app, &id);
+    let result = crate::containers::delete(&app, &id, delete_files);
     match &result {
         Ok(_) => {
             crate::operations::complete(&app, &operation.id)?;

--- a/src-tauri/src/containers.rs
+++ b/src-tauri/src/containers.rs
@@ -48,7 +48,11 @@ pub fn save(app: &tauri::AppHandle, environment: Environment) -> Result<Vec<Envi
     list(app)
 }
 
-pub fn delete(app: &tauri::AppHandle, id: &str) -> Result<Vec<Environment>, String> {
+pub fn delete(
+    app: &tauri::AppHandle,
+    id: &str,
+    delete_files: bool,
+) -> Result<Vec<Environment>, String> {
     if !safe_resource_id(id) {
         return Err("Invalid environment identifier".into());
     }
@@ -77,6 +81,9 @@ pub fn delete(app: &tauri::AppHandle, id: &str) -> Result<Vec<Environment>, Stri
         }
         if let Err(error) = crate::environment_files::remove(app, &site.id) {
             cleanup_errors.push(format!("env file for {}: {error}", site.id));
+        }
+        if !delete_files {
+            continue;
         }
         let directory = PathBuf::from(&site.directory);
         if directory.exists() {

--- a/src-tauri/src/project_export.rs
+++ b/src-tauri/src/project_export.rs
@@ -265,7 +265,10 @@ pub fn import(
         let error = crate::security::environment_error(app, environment_id, error);
         if environment_saved {
             let _ = crate::containers::operate(app, environment_id, "destroy");
-            let _ = crate::containers::delete(app, environment_id);
+            // `false`: baseline.rollback() right below handles the project
+            // directory already, same reasoning as the `sites::delete(..., false)`
+            // call above.
+            let _ = crate::containers::delete(app, environment_id, false);
         }
         let _ = crate::sites::delete(app, &site_id, false);
         let _ = baseline.rollback();

--- a/src-tauri/src/site_commands.rs
+++ b/src-tauri/src/site_commands.rs
@@ -116,7 +116,7 @@ fn rollback_created_project(
     let _ = project_templates::prepare_for_removal(app, project, environment);
     let _ = containers::operate(app, &environment.id, "destroy");
     let _ = storage::delete_site(app, &project.id);
-    let _ = containers::delete(app, &environment.id);
+    let _ = containers::delete(app, &environment.id, true);
     let _ = containers::refresh_gateway(app);
     rollback_directory_error(baseline, original)
 }
@@ -200,7 +200,7 @@ pub async fn create_project_environment(
         let created = match sites::create(&worker, site) {
             Ok(value) => value,
             Err(error) => {
-                let _ = containers::delete(&worker, &environment.id);
+                let _ = containers::delete(&worker, &environment.id, true);
                 return Err(rollback_directory_error(&directory_baseline, error));
             }
         };
@@ -613,7 +613,11 @@ pub async fn duplicate_site(
                 if let Err(cleanup) = containers::operate(&worker, &environment_id, "destroy") {
                     rollback_errors.push(format!("containers: {cleanup}"));
                 }
-                if let Err(cleanup) = containers::delete(&worker, &environment_id) {
+                // `false`: the project directory is handled by baseline.rollback()
+                // right below - letting containers::delete's own file cleanup run
+                // too would have both mechanisms racing to rename/remove the same
+                // directory.
+                if let Err(cleanup) = containers::delete(&worker, &environment_id, false) {
                     rollback_errors.push(format!("environment record: {cleanup}"));
                 }
             }

--- a/src/features/environment-window/components/delete-dialog.tsx
+++ b/src/features/environment-window/components/delete-dialog.tsx
@@ -15,9 +15,11 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Progress } from "@/components/ui/progress"
 import { errorMessage } from "@/lib/errors"
 import { pickLanguage } from "@/i18n"
+import type { Site } from "@/types"
 
 export function DeleteEnvironmentDialog({
   id,
@@ -40,10 +42,19 @@ export function DeleteEnvironmentDialog({
 }) {
   const text = pickLanguage(language).environmentWindow
   const [deleteOpen, setDeleteOpen] = React.useState(false)
+  const [deleteFiles, setDeleteFiles] = React.useState(true)
+  const [affectedSites, setAffectedSites] = React.useState<Site[]>([])
   const [deleteProgress, setDeleteProgress] = React.useState<{
     value: number
     stage: string
   } | null>(null)
+
+  React.useEffect(() => {
+    if (!deleteOpen || !id) return
+    void invoke<Site[]>("list_sites").then((sites) =>
+      setAffectedSites(sites.filter((site) => site.environmentId === id)),
+    )
+  }, [deleteOpen, id])
 
   async function remove() {
     if (!id) return
@@ -54,7 +65,7 @@ export function DeleteEnvironmentDialog({
       setDeleteProgress({ value: 35, stage: text.stoppingContainers })
       await invoke("operate_environment", { id, action: "destroy" })
       setDeleteProgress({ value: 85, stage: text.removingData })
-      await invoke("delete_environment", { id })
+      await invoke("delete_environment", { id, deleteFiles })
       setDeleteProgress({ value: 95, stage: text.updatingList })
       await emit("environments-changed")
       setDeleteProgress({ value: 100, stage: text.environmentDeleted })
@@ -84,9 +95,20 @@ export function DeleteEnvironmentDialog({
             {deleteProgress ? text.deletingEnvironment : text.deleteEnvironmentTitle(name)}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            {deleteProgress ? text.keepOpenHint : text.deleteEnvironmentDescription}
+            {deleteProgress
+              ? text.keepOpenHint
+              : text.deleteEnvironmentDescription(affectedSites.map((site) => site.name))}
           </AlertDialogDescription>
         </AlertDialogHeader>
+        {!deleteProgress && affectedSites.length > 0 && (
+          <label className="flex items-center gap-3 rounded-lg border p-3 text-sm">
+            <Checkbox
+              checked={deleteFiles}
+              onCheckedChange={(value) => setDeleteFiles(Boolean(value))}
+            />
+            <span>{text.deleteFilesLabel}</span>
+          </label>
+        )}
         {deleteProgress && (
           <div className="grid gap-2 py-2">
             <div className="flex items-center justify-between gap-4 text-sm">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -410,8 +410,11 @@ const en = {
     deletingEnvironment: "Deleting environment…",
     deleteEnvironmentTitle: (name: string) => `Delete ${name}?`,
     keepOpenHint: "Keep LS Panel open until all container resources have been removed.",
-    deleteEnvironmentDescription:
-      "This permanently removes the environment containers, generated stack, database volume, and related site records. This action cannot be undone.",
+    deleteEnvironmentDescription: (siteNames: string[]) =>
+      siteNames.length
+        ? `This permanently removes the environment containers, generated stack, and database volume, along with ${siteNames.length} project${siteNames.length === 1 ? "" : "s"} — ${siteNames.join(", ")}. This action cannot be undone.`
+        : "This permanently removes the environment containers, generated stack, and database volume. This action cannot be undone.",
+    deleteFilesLabel: "Also delete project files from disk",
     cancel: "Cancel",
     deleting: "Deleting…",
     deleteEnvironment: "Delete environment",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -450,8 +450,21 @@ const uk: Dictionary = {
     deletingEnvironment: "Видалення середовища…",
     deleteEnvironmentTitle: (name: string) => `Видалити ${name}?`,
     keepOpenHint: "Тримайте LS Panel відкритим, доки всі контейнерні ресурси не буде видалено.",
-    deleteEnvironmentDescription:
-      "Це остаточно видалить контейнери середовища, згенерований стек, том бази даних та пов'язані записи сайтів. Цю дію не можна скасувати.",
+    deleteEnvironmentDescription: (siteNames: string[]) => {
+      if (!siteNames.length)
+        return "Це остаточно видалить контейнери середовища, згенерований стек і том бази даних. Цю дію не можна скасувати."
+      const count = siteNames.length
+      const mod10 = count % 10
+      const mod100 = count % 100
+      const word =
+        mod10 === 1 && mod100 !== 11
+          ? "проєкт"
+          : mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)
+            ? "проєкти"
+            : "проєктів"
+      return `Це остаточно видалить контейнери середовища, згенерований стек і том бази даних, а також ${count} ${word} — ${siteNames.join(", ")}. Цю дію не можна скасувати.`
+    },
+    deleteFilesLabel: "Також видалити файли проєктів з диска",
     cancel: "Скасувати",
     deleting: "Видалення…",
     deleteEnvironment: "Видалити середовище",


### PR DESCRIPTION
## Summary
- `containers::delete` cascaded to quarantine-then-delete every project directory for every site sharing the environment, unconditionally — unlike `delete_site`, which already has a `deleteFiles` checkbox. The confirmation dialog's generic wording didn't name or count the affected projects either, or mention that files on disk get deleted.
- `delete()` now takes a `delete_files` flag; the project-directory quarantine block is the only part gated by it — backups, snapshots, and env-file records (LS Panel's own managed data, not user files) stay unconditional, the same split `delete_site` already uses.
- The Containers window's delete dialog fetches the affected sites via the existing `list_sites` command when it opens, lists them by name in the confirmation text, and adds a "delete files" checkbox defaulting to `true` (preserves today's always-delete behavior unless unchecked).
- The four internal rollback call sites (aborted project creation/duplication/import) now pass `delete_files` explicitly: `true` for the two where the site record was never created or was already removed from the DB before the call (the quarantine loop has nothing to act on either way), and `false` for the two duplicate/import rollback paths that already call `baseline.rollback()` separately for the same directory — passing `true` there would have both mechanisms racing to rename/remove it.

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 153 passed (no unit test added for `delete()` itself — the project has no existing pattern for mocking `tauri::AppHandle` in unit tests, so I didn't invent one for this fix; recommend exercising it manually: delete an environment with 2+ projects, confirm the dialog lists them by name, and confirm the "delete files" checkbox controls whether their directories survive)
- [x] `npx tsc --noEmit` / `npx eslint . --max-warnings 0` / `npx prettier --check` — clean
- [x] `npm run test:frontend` — 8/8 pass (includes i18n key-parity for the new `deleteFilesLabel` key and the now-function-typed `deleteEnvironmentDescription`)
- [x] `npm run build` — succeeds