### PR TITLE
Allow Cron, Elasticsearch, MinIO, and RabbitMQ services in the Terminal tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinning or archiving a project from its own details page no longer navigates you back to the sites list — only editing its settings or duplicating it does that now.
 - Duplicating or importing a project now shows real progress (stage and percentage) instead of a static "Duplicating…"/"Importing…" label for what can be a multi-minute operation.
 - Removing an extra service (Redis, MinIO, etc.) from a running environment and saving no longer leaves its container running with no way to stop it — saving now reconciles the running stack with the updated configuration.
+- The Terminal tab rejected Cron, Elasticsearch, MinIO, and RabbitMQ with "Unsupported terminal service" even though they're selectable in its service list — the same class of dead button already fixed elsewhere for these services, but missed for the Terminal feature specifically.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/containers.rs
+++ b/src-tauri/src/containers.rs
@@ -840,6 +840,10 @@ pub fn terminal_context(
         "mailpit",
         "adminer",
         "phpmyadmin",
+        "cron",
+        "elasticsearch",
+        "minio",
+        "rabbitmq",
     ];
     if !SERVICES.contains(&service) {
         return Err("Unsupported terminal service".into());


### PR DESCRIPTION
## Summary

- `containers::terminal_context`'s service allowlist was missing `cron`, `elasticsearch`, `minio`, and `rabbitmq`, even though the Terminal tab's own service dropdown lists them unfiltered (it's built from `environment.extraServices`) and `service_context` (used for exec/log/restart) already supports all four.
- Selecting any of these four in the Terminal tab immediately failed with "Unsupported terminal service" — a dead option in the list.
- Verified live against the actual images (not assumed) that all three third-party images have a shell: `docker.elastic.co/elasticsearch/elasticsearch:8.15.3`, `docker.io/minio/minio`, and `docker.io/library/rabbitmq:3.13-management` all have `/bin/sh`. `cron` runs the same `Dockerfile.php` base image as `web`/`php`, which the terminal already supports.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (153 passed)