### PR TITLE
Prune automatic pre-restore snapshots down to the retention limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinning or archiving a project from its own details page no longer navigates you back to the sites list — only editing its settings or duplicating it does that now.
 - Duplicating or importing a project now shows real progress (stage and percentage) instead of a static "Duplicating…"/"Importing…" label for what can be a multi-minute operation.
 - Removing an extra service (Redis, MinIO, etc.) from a running environment and saving no longer leaves its container running with no way to stop it — saving now reconciles the running stack with the updated configuration.
+- Restoring a project snapshot no longer leaves an unbounded pile of automatic pre-restore safety snapshots on disk — each one is now pruned down to the same 20-snapshot retention already applied to every other automatic snapshot.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/snapshots.rs
+++ b/src-tauri/src/snapshots.rs
@@ -240,6 +240,7 @@ pub fn restore(app: &tauri::AppHandle, site_id: &str, id: &str) -> Result<(), St
         crate::containers::operate(app, &manifest.environment.id, "start")?;
     }
     let safety = create(app, site_id, "Automatic pre-restore snapshot")?;
+    prune(app, site_id, 20, None)?;
     let safety_directory = root(app, site_id)?.join(&safety.id);
     let safety_manifest = load_manifest(&safety_directory)?;
     run_with_rollback(


### PR DESCRIPTION
## Summary

- `snapshots::restore` creates an "Automatic pre-restore snapshot" before applying a restore, but never pruned old ones afterward — unlike its sibling `create_safety_for_environment`, which always calls `prune(app, &site.id, 20, None)` right after creating its own automatic snapshot.
- Since restoring is a normal, repeatable workflow, every restore left behind a full database dump forever with no cleanup and no user-visible cue.
- Fix: `restore` now prunes to the same 20-snapshot retention immediately after creating the safety snapshot. `prune` keeps the newest N (sorted newest-first), so the just-created snapshot always survives — only older ones are removed.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (153 passed, includes the existing `retention_keeps_the_newest_snapshots` coverage of the underlying prune logic)