### PR TITLE
Route scheduled database backups through the operations/notification pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinning or archiving a project from its own details page no longer navigates you back to the sites list — only editing its settings or duplicating it does that now.
 - Duplicating or importing a project now shows real progress (stage and percentage) instead of a static "Duplicating…"/"Importing…" label for what can be a multi-minute operation.
 - Removing an extra service (Redis, MinIO, etc.) from a running environment and saving no longer leaves its container running with no way to stop it — saving now reconciles the running stack with the updated configuration.
+- Scheduled database backups now go through the same Operation Center/notification pipeline as manual backups — a failed scheduled backup (e.g. because the environment isn't running) used to fail completely silently, with no entry anywhere and no way to know it didn't happen.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/backup_scheduler.rs
+++ b/src-tauri/src/backup_scheduler.rs
@@ -18,13 +18,26 @@ fn run_due_backups(app: &tauri::AppHandle) {
         if !environment.backup_schedule_enabled || !is_due(app, &environment) {
             continue;
         }
-        if crate::backups::create(app, &environment.id).is_ok() {
-            let _ = crate::backups::prune(
-                app,
-                &environment.id,
-                environment.backup_retention_count as usize,
-                None,
-            );
+        let Ok(operation) =
+            crate::operations::create(app, Some(&environment.id), "database-backup")
+        else {
+            // Another operation is already running for this environment;
+            // try again next tick instead of racing it.
+            continue;
+        };
+        match crate::backups::create(app, &environment.id) {
+            Ok(_) => {
+                let _ = crate::operations::complete(app, &operation.id);
+                let _ = crate::backups::prune(
+                    app,
+                    &environment.id,
+                    environment.backup_retention_count as usize,
+                    None,
+                );
+            }
+            Err(error) => {
+                let _ = crate::operations::fail(app, &operation.id, &error);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- `backup_scheduler::run_due_backups` called `backups::create`/`backups::prune` directly, unlike every manual backup path (`database_commands::run_operation`), which wraps the same calls in `operations::create`/`complete`/`fail`.
- Because the scheduler never created an `Operation` row, a failed scheduled backup (e.g. the environment isn't running) produced no Operation Center entry and no success/failure notification — it failed completely silently, every time.
- Fix: the scheduler now creates an operation before each scheduled backup and completes/fails it the same way the manual path does, so failures are visible and `notify_operation`'s existing success/failure notification fires (respecting the user's `notify_on_operations` setting). If an environment already has an active operation, the scheduler now skips it for this tick instead of racing it, and retries on the next one.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (153 passed)