### PR TITLE
Refresh the database backups list after Quick Backup, Clear Database, or an import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinning or archiving a project from its own details page no longer navigates you back to the sites list — only editing its settings or duplicating it does that now.
 - Duplicating or importing a project now shows real progress (stage and percentage) instead of a static "Duplicating…"/"Importing…" label for what can be a multi-minute operation.
 - Removing an extra service (Redis, MinIO, etc.) from a running environment and saving no longer leaves its container running with no way to stop it — saving now reconciles the running stack with the updated configuration.
+- The Database page's backup list no longer goes stale after "Quick Backup," "Clear Database," or an SQL/table import — each of these can create a backup on the backend, but the visible list only refreshed after navigating away and back.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src/features/backups/components/database-backups.tsx
+++ b/src/features/backups/components/database-backups.tsx
@@ -40,10 +40,12 @@ export function DatabaseBackups({
   environment,
   language,
   onChanged,
+  refreshToken,
 }: {
   environment: Environment
   language: string
   onChanged?: () => void
+  refreshToken?: number
 }) {
   const text = pickLanguage(language).databaseBackups
   const [items, setItems] = React.useState<DatabaseBackup[]>([])
@@ -69,7 +71,11 @@ export function DatabaseBackups({
   )
   React.useEffect(() => {
     void refresh()
-  }, [refresh])
+    // refreshToken has no meaning of its own — the parent bumps it to signal
+    // that a sibling action (Quick Backup, Clear Database, Import…) may have
+    // changed the backup list, so it's listed here purely to retrigger this
+    // effect.
+  }, [refresh, refreshToken])
   React.useEffect(() => {
     let disposed = false
     invoke("database_info", { environmentId: environment.id })

--- a/src/features/database/database-page.tsx
+++ b/src/features/database/database-page.tsx
@@ -286,6 +286,7 @@ function DatabaseDetails({
   const [tableImportError, setTableImportError] = React.useState("")
   const [importTablesLoading, setImportTablesLoading] = React.useState(false)
   const [databaseReachable, setDatabaseReachable] = React.useState(true)
+  const [backupsRefreshToken, setBackupsRefreshToken] = React.useState(0)
 
   const load = React.useCallback(async () => {
     setBusy(true)
@@ -330,6 +331,7 @@ function DatabaseDetails({
       await invoke(command, { environmentId: environment.id, ...payload })
       setMessage(success)
       setMessageOk(true)
+      setBackupsRefreshToken((value) => value + 1)
     } catch (value) {
       setMessage(errorMessage(value))
       setMessageOk(false)
@@ -705,7 +707,11 @@ function DatabaseDetails({
       </Card>
 
       <DatabaseConsole environment={environment} language={language} />
-      <DatabaseBackups environment={environment} language={language} />
+      <DatabaseBackups
+        environment={environment}
+        language={language}
+        refreshToken={backupsRefreshToken}
+      />
 
       <Dialog
         open={Boolean(cloneSource)}


### PR DESCRIPTION
## Summary

- The Database page's "Quick Backup" button, and its "Clear Database"/"Import SQL"/"Import Tables" actions (each of which creates an automatic pre-action backup server-side), all call the backend directly through a shared `action()` helper — bypassing the embedded `<DatabaseBackups>` component's own `create()` method, which is the only thing that triggered its internal list refresh.
- Result: the backup list stayed stale after any of these until navigating away and back.
- Fix: `DatabaseBackups` gains an optional `refreshToken` prop that retriggers its fetch effect when it changes (without resetting its own local UI state, unlike remounting via `key`). `database-page.tsx`'s shared `action()` helper now bumps a `backupsRefreshToken` counter on every successful call and passes it down.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint . --max-warnings 0`
- [x] `npm run test:frontend` (8 passed)