### PR TITLE
Serialize certificate reissue/delete/reset against concurrent TLS generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinning or archiving a project from its own details page no longer navigates you back to the sites list — only editing its settings or duplicating it does that now.
 - Duplicating or importing a project now shows real progress (stage and percentage) instead of a static "Duplicating…"/"Importing…" label for what can be a multi-minute operation.
 - Removing an extra service (Redis, MinIO, etc.) from a running environment and saving no longer leaves its container running with no way to stop it — saving now reconciles the running stack with the updated configuration.
+- Reissuing, deleting, or resetting the local HTTPS certificate now takes the same lock that already serializes certificate generation — previously only `ensure()` took it, so one of these actions running while an environment started (or another window refreshed the gateway) could delete `local.crt`/`local.key` out from under an in-progress write.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/tls.rs
+++ b/src-tauri/src/tls.rs
@@ -290,6 +290,7 @@ fn certificate_fingerprint(path: &Path) -> Option<String> {
 }
 
 pub fn force_reissue(app: &tauri::AppHandle) -> Result<(), String> {
+    let _lock = TLS_LOCK.lock().unwrap_or_else(|error| error.into_inner());
     let directory = root(app)?;
     for name in ["local.crt", "local.key", "domains.txt"] {
         let path = directory.join(name);
@@ -302,6 +303,7 @@ pub fn force_reissue(app: &tauri::AppHandle) -> Result<(), String> {
 }
 
 pub fn remove_server_certificate(app: &tauri::AppHandle) -> Result<(), String> {
+    let _lock = TLS_LOCK.lock().unwrap_or_else(|error| error.into_inner());
     let directory = root(app)?;
     for name in [
         "local.crt",
@@ -320,6 +322,7 @@ pub fn remove_server_certificate(app: &tauri::AppHandle) -> Result<(), String> {
 }
 
 pub fn reset_ca(app: &tauri::AppHandle) -> Result<(), String> {
+    let _lock = TLS_LOCK.lock().unwrap_or_else(|error| error.into_inner());
     for store in browser_stores() {
         let database = format!("sql:{}", store.display());
         let _ = Command::new("certutil")


### PR DESCRIPTION
## Summary

- `TLS_LOCK` exists specifically to prevent interleaved writes to `local.key`/`local.crt`/`domains.txt`, but was only taken by `ensure()`. `force_reissue`, `remove_server_certificate`, and `reset_ca` all delete those same files directly, without the lock.
- `ensure()` runs on every environment start/restart, every site add, and every LiveLink start/stop (via `refresh_gateway`). A user clicking "Reissue" or "Delete HTTPS certificate" while another window is starting an environment could delete `local.crt`/`local.key` out from under an in-progress `ensure()` write, surfacing an unrelated "No such file" error to whichever operation loses the race.
- Fix: all three functions now take `TLS_LOCK` at their start, matching `ensure()`. Verified none of the three call `ensure()` (or anything that would) internally, so there's no deadlock risk from the non-reentrant `Mutex`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (153 passed)