### PR TITLE
Skip file-ownership repair for native (containerless) projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reissuing, deleting, or resetting the local HTTPS certificate now takes the same lock that already serializes certificate generation — previously only `ensure()` took it, so one of these actions running while an environment started (or another window refreshed the gateway) could delete `local.crt`/`local.key` out from under an in-progress write.
 - A failed LiveLink start for one site no longer restarts (and briefly disrupts) every other site's already-running tunnel — rolling back a failed attempt now only touches the site that was actually being changed.
 - LiveLink's "Stop" button in the Running Projects table now stops just that project's tunnel instead of every active tunnel at once; the page-level "Stop" button remains as a stop-everything option.
+- Deleting a native (containerless) project's files always failed with "Failed to launch temporary project file permission repair: No such file or directory" — the ownership-repair step it ran before deletion assumed a container stack existed, which native projects never have. Native projects' files are already owned by the host user, so the repair step is now skipped for them entirely.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src-tauri/src/project_templates.rs
+++ b/src-tauri/src/project_templates.rs
@@ -613,6 +613,13 @@ fn restore_ownership(
     site: &Site,
     environment: &Environment,
 ) -> Result<(), String> {
+    // Native (containerless) projects are never touched by a container
+    // process, so their files are already owned by the host user — nothing
+    // to repair, and there's no compose stack to run the repair command in
+    // anyway (attempting it fails outright with "no such file or directory").
+    if environment.runtime_mode == "native" {
+        return Ok(());
+    }
     let settings = crate::settings::load(app)?.ok_or("Settings not found")?;
     let metadata = fs::metadata(&settings.sites_directory)
         .map_err(|error| format!("Failed to inspect sites directory ownership: {error}"))?;


### PR DESCRIPTION
## Summary

- `sites::delete()` calls `project_templates::prepare_for_removal` → `repair_permissions` → `restore_ownership` before removing a project's files, to fix ownership on files a container may have written as root. `restore_ownership` unconditionally tries to run a `docker/podman compose run` command in the environment's stack directory — but a native (containerless) project has no compose stack at all, so this fails immediately with "Failed to launch temporary project file permission repair: No such file or directory," blocking deletion entirely for every native project.
- Native projects are never touched by a container process — their files are always already owned by the host user, so the repair step has nothing to do. `restore_ownership` now returns early when `environment.runtime_mode == "native"`, fixing all four call sites (deletion, the explicit environment-start repair pass, and the two site_commands.rs call sites) at the source.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (153 passed)