### PR TITLE
Fix the Sites list's Git branch badge always being empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleting a native (containerless) project's files always failed with "Failed to launch temporary project file permission repair: No such file or directory" — the ownership-repair step it ran before deletion assumed a container stack existed, which native projects never have. Native projects' files are already owned by the host user, so the repair step is now skipped for them entirely.
 - Native (containerless) sites now open at their real `https://<name>.localhost` domain through the local HTTPS gateway, the same as containerized sites, instead of always showing a raw `127.0.0.1:<port>` address. When Docker/Podman is available, the native process additionally binds to Docker's host-gateway bridge address (never `0.0.0.0`, so the port stays unreachable from the local network) so the gateway can reach it; when it isn't, the site still falls back to `127.0.0.1:<port>` exactly as before — native mode continues to need no container runtime at all.
 - The project wizard could show a "domain already in use" error on its final step right after successfully creating the project — the newly created site reappearing in the live sites list (refreshed in the background) made the wizard's own domain-conflict check match against itself.
+- The Sites list's Git branch badge never showed for any project — it checked for a repository at the project's root directory instead of its `app/` subdirectory, where it actually lives.
 
 ## [0.5.1-beta] - 2026-08-10
 

--- a/src/features/sites/sites-page.tsx
+++ b/src/features/sites/sites-page.tsx
@@ -162,9 +162,9 @@ export function SitesPage({
               [
                 site.id,
                 (
-                  await invoke<GitStatus>("site_git_status", { directory: site.directory }).catch(
-                    () => null,
-                  )
+                  await invoke<GitStatus>("site_git_status", {
+                    directory: `${site.directory}/app`,
+                  }).catch(() => null)
                 )?.branch ?? "",
               ] as const,
           ),


### PR DESCRIPTION
## Summary

- `sites-page.tsx` calls `site_git_status` with `directory: site.directory` (the project root), but every project's actual git repository lives at `site.directory/app`, per the convention already used consistently everywhere else in the codebase (`use-site-git.ts`, `git_status_monitor.rs`).
- Since `.git` never exists at the project root, `site_git_status` always resolves to "not a repository," so the Git branch badge on the Sites list silently never appeared for any project, git-initialized or not.
- Fix: append `/app` to match the convention used everywhere else.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint . --max-warnings 0`