### PR TITLE
Fix env-file cleanup on environment delete and remaining Russian strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comparing a project snapshot against the current project almost always flagged a "configuration change" that wasn't real — it included `lastStartedAt`, which updates on every environment start, burying genuine config drift in noise.
 - The database query console silently cut off large results at 1,000,000 characters with no indication — a large `SELECT` looked complete when it wasn't. It now appends a clear marker when this happens.
 - Starting or restarting an environment could drop a placeholder `index.html`/`index.php` right into the project's root folder instead of its `app/` subdirectory, next to (not inside) the real project — it checked for and wrote starter files at the wrong location, unlike project creation which already got this right.
+- Deleting an environment always failed to remove its projects' `.env` files ("Site not found"), leaving them behind on disk — the cleanup step looked the site back up in storage after its record had already been cascade-deleted along with the environment. It now uses the project directory captured before deletion instead of re-querying storage.
+- A missing environment during Start/Stop/Restart/Destroy showed the raw error "Окружение не найдено" (Russian) instead of an English/Ukrainian message.
+- Six more validation and status messages (environment name, port range, image version, missing Docker/Podman, and "complete initial setup first") were hardcoded in Russian instead of the app's supported English/Ukrainian.
 
 ### Security
 

--- a/src-tauri/src/container_runtime.rs
+++ b/src-tauri/src/container_runtime.rs
@@ -59,7 +59,7 @@ pub fn detect(preferred: Option<&str>) -> RuntimeStatus {
         running: false,
         version: None,
         compose_available: false,
-        message: "Docker или Podman не найден".into(),
+        message: "Docker or Podman not found".into(),
     })
 }
 

--- a/src-tauri/src/container_validation.rs
+++ b/src-tauri/src/container_validation.rs
@@ -16,14 +16,14 @@ pub(crate) fn validate_identity_and_platform(environment: &Environment) -> Resul
         );
     }
     if environment.name.trim().is_empty() {
-        return Err("Название окружения обязательно".into());
+        return Err("Environment name is required".into());
     }
     if !environment
         .name
         .chars()
         .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
     {
-        return Err("Название может содержать только латиницу, цифры, - и _".into());
+        return Err("Name may contain only Latin letters, digits, - and _".into());
     }
     if !matches!(environment.web_server.as_str(), "Apache" | "Nginx") {
         return Err("Unsupported web server".into());
@@ -40,9 +40,9 @@ pub(crate) fn validate_identity_and_platform(environment: &Environment) -> Resul
     let port: u16 = environment
         .port
         .parse()
-        .map_err(|_| "Порт должен быть числом от 1 до 65535")?;
+        .map_err(|_| "Port must be a number from 1 to 65535")?;
     if port == 0 {
-        return Err("Порт должен быть числом от 1 до 65535".into());
+        return Err("Port must be a number from 1 to 65535".into());
     }
     for value in [
         &environment.web_version,
@@ -59,7 +59,7 @@ pub(crate) fn validate_identity_and_platform(environment: &Environment) -> Resul
                 character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
             })
         {
-            return Err("Недопустимая версия образа".into());
+            return Err("Invalid image version".into());
         }
     }
     if !matches!(

--- a/src-tauri/src/containers.rs
+++ b/src-tauri/src/containers.rs
@@ -117,7 +117,7 @@ pub fn delete(
         if let Err(error) = crate::snapshots::delete_all(app, &site.id) {
             cleanup_errors.push(format!("snapshots for {}: {error}", site.id));
         }
-        if let Err(error) = crate::environment_files::remove(app, &site.id) {
+        if let Err(error) = crate::environment_files::remove_for_directory(app, &site.directory) {
             cleanup_errors.push(format!("env file for {}: {error}", site.id));
         }
         if !delete_files {
@@ -186,7 +186,7 @@ fn operate_inner(
     let environment = list(app)?
         .into_iter()
         .find(|item| item.id == id)
-        .ok_or("Окружение не найдено")?;
+        .ok_or("Environment not found")?;
     validate(&environment)?;
     if environment.runtime_mode == "native" {
         return crate::native_runtime::operate(app, &environment, action);
@@ -1108,8 +1108,7 @@ pub(crate) fn prepare(
     let elasticsearch_dir = elasticsearch_directory(app, &environment.id)?;
     let minio_dir = minio_directory(app, &environment.id)?;
     let rabbitmq_dir = rabbitmq_directory(app, &environment.id)?;
-    let settings =
-        crate::settings::load(app)?.ok_or("Сначала завершите первоначальную настройку")?;
+    let settings = crate::settings::load(app)?.ok_or("Complete the initial setup first")?;
     let sites_directory = PathBuf::from(settings.sites_directory);
     fs::create_dir_all(&directory).map_err(|error| error.to_string())?;
     fs::create_dir_all(&sites_directory).map_err(|error| error.to_string())?;

--- a/src-tauri/src/environment_files.rs
+++ b/src-tauri/src/environment_files.rs
@@ -92,7 +92,19 @@ pub fn write(app: &tauri::AppHandle, site_id: &str, text: &str) -> Result<Enviro
 }
 
 pub fn remove(app: &tauri::AppHandle, site_id: &str) -> Result<(), String> {
-    let path = env_path(app, site_id)?;
+    remove_at(env_path(app, site_id)?)
+}
+
+// Removes a site's `.env` by its already-known directory rather than looking
+// the site up in storage — used when the site's storage record no longer
+// exists (e.g. mid-way through deleting its parent environment, after
+// `storage::delete_environment` has already cascaded the site row away, but
+// the on-disk `.env` still needs cleaning up).
+pub fn remove_for_directory(app: &tauri::AppHandle, site_directory: &str) -> Result<(), String> {
+    remove_at(env_path_for_directory(app, site_directory)?)
+}
+
+fn remove_at(path: PathBuf) -> Result<(), String> {
     if !path.exists() {
         return Ok(());
     }
@@ -278,10 +290,14 @@ fn env_path(app: &tauri::AppHandle, site_id: &str) -> Result<PathBuf, String> {
         .into_iter()
         .find(|site| site.id == site_id)
         .ok_or("Site not found")?;
+    env_path_for_directory(app, &site.directory)
+}
+
+fn env_path_for_directory(app: &tauri::AppHandle, site_directory: &str) -> Result<PathBuf, String> {
     let settings = crate::settings::load(app)?.ok_or("Settings not found")?;
     let root = fs::canonicalize(&settings.sites_directory)
         .map_err(|error| format!("Invalid sites directory: {error}"))?;
-    let directory = fs::canonicalize(&site.directory)
+    let directory = fs::canonicalize(site_directory)
         .map_err(|error| format!("Invalid site directory: {error}"))?;
     if !directory.starts_with(&root) {
         return Err("The site directory is outside the configured sites directory".into());


### PR DESCRIPTION
## Summary
- Deleting an environment always failed to remove its projects' `.env` files ("Site not found"): the cleanup step looked the site back up in storage by id, but `storage::delete_environment` had already cascade-deleted that row by the time cleanup ran, so the lookup failed on every single deletion, matching the "Delete-Environment failed: env file for site-...: Site not found" error observed in production. Added `environment_files::remove_for_directory()`, which uses the project directory already captured before deletion instead of re-querying storage.
- Translated seven remaining Russian strings across `containers.rs`, `container_runtime.rs`, and `container_validation.rs` that were missed by the earlier Russian-string cleanup — including `"Окружение не найдено"`, which was surfacing raw in Start/Stop/Restart/Destroy failures (also observed in production: repeated "Destroy failed... Окружение не найдено").

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (162 passed, 0 failed, 2 ignored)