### PR TITLE
Serve/run native sites from app/, not the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleting an environment always failed to remove its projects' `.env` files ("Site not found"), leaving them behind on disk — the cleanup step looked the site back up in storage after its record had already been cascade-deleted along with the environment. It now uses the project directory captured before deletion instead of re-querying storage.
 - A missing environment during Start/Stop/Restart/Destroy showed the raw error "Окружение не найдено" (Russian) instead of an English/Ukrainian message.
 - Six more validation and status messages (environment name, port range, image version, missing Docker/Podman, and "complete initial setup first") were hardcoded in Russian instead of the app's supported English/Ukrainian.
+- Starting a native (containerless) site served files (or ran `npm`/`pnpm`) from the project's root folder instead of its `app/` subdirectory, so a freshly created static/Node.js project always 404'd — its `index.html`/`package.json` live in `app/`, not the root.
 
 ### Security
 

--- a/src-tauri/src/native_runtime.rs
+++ b/src-tauri/src/native_runtime.rs
@@ -218,7 +218,13 @@ fn start(app: &tauri::AppHandle, environment: &Environment) -> Result<(), String
         .port
         .parse()
         .map_err(|_| "Invalid port for this environment")?;
-    let directory = PathBuf::from(&site.directory);
+    // The project's actual source lives in `app/`, not the site's root
+    // directory — the same convention used everywhere else (git status, the
+    // file manager, environment_files, sites::create). Serving/running from
+    // the bare root instead left the static server and Node process unable
+    // to find the very files ensure_directories() had just seeded into
+    // `app/`, producing a 404 on every fresh native site.
+    let directory = PathBuf::from(&site.directory).join("app");
     if !directory.is_dir() {
         return Err(format!(
             "Project directory not found: {}",


### PR DESCRIPTION
## Summary
- `native_runtime::start()` used the project's root directory (`site.directory`) instead of its `app/` subdirectory to both serve static files and run `npm`/`pnpm` for Node.js projects.
- `sites::ensure_directories()`/`create()` seed the starter `index.html`/`package.json` into `app/` (the same convention used everywhere else — git status, file manager, `environment_files`, project export). With the static server/Node process looking at the root instead, a freshly created native static or Node.js site always 404'd — nothing to serve, or `package.json` not found.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (162 passed, 0 failed, 2 ignored)