### PR TITLE
Regenerate MinIO/RabbitMQ passwords on project import, fixing every import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A missing environment during Start/Stop/Restart/Destroy showed the raw error "Окружение не найдено" (Russian) instead of an English/Ukrainian message.
 - Six more validation and status messages (environment name, port range, image version, missing Docker/Podman, and "complete initial setup first") were hardcoded in Russian instead of the app's supported English/Ukrainian.
 - Starting a native (containerless) site served files (or ran `npm`/`pnpm`) from the project's root folder instead of its `app/` subdirectory, so a freshly created static/Node.js project always 404'd — its `index.html`/`package.json` live in `app/`, not the root.
+- Importing an exported project bundle always failed with a "MinIO root password must be at least 8 characters" error, regardless of whether the original environment used MinIO or RabbitMQ at all — export blanks those passwords like every other secret, but import never regenerated them the way it already did for the database password.
 
 ### Security
 

--- a/src-tauri/src/project_export.rs
+++ b/src-tauri/src/project_export.rs
@@ -191,6 +191,13 @@ pub fn import(
     environment.database_container_name.clear();
     environment.database_password = crate::environment_files::generate_secret(32)?;
     environment.database_root_password = crate::environment_files::generate_secret(32)?;
+    // MinIO/RabbitMQ passwords are required and validated unconditionally
+    // (unlike Redis, which allows an empty password), so they must always be
+    // regenerated here even for environments that don't actually use those
+    // services — otherwise `containers::save` below rejects every single
+    // import with a "password must be at least 8 characters" error.
+    environment.minio_root_password = crate::environment_files::generate_secret(32)?;
+    environment.rabbitmq_password = crate::environment_files::generate_secret(32)?;
     if environment
         .extra_services
         .iter()


### PR DESCRIPTION
## Summary
- Exporting a project blanks `minio_root_password`/`rabbitmq_password` like every other generated secret (`strip_infrastructure_secrets`), but `import()` only ever regenerated `database_password`/`database_root_password` (and `redis_password` when Redis is enabled) — never these two.
- `container_validation.rs` requires both unconditionally, regardless of whether the environment actually uses MinIO/RabbitMQ. Since `import()` calls `containers::save()`, which validates first, importing **any** exported project bundle always failed with "MinIO root password must be at least 8 characters..." — the entire export/import feature was non-functional.
- Fix: always regenerate both passwords on import, the same way the database passwords already are (`generate_secret(32)` — hex output, satisfies both fields' alphanumeric-only requirement).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (162 passed, 0 failed, 2 ignored)