### PR TITLE
Fix live-log service allowlist gap and a disk leak on environment delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stopping or starting a site from the Ctrl+K quick-actions palette acted on its entire environment instead of just that site — for two sites sharing one environment, stopping one from the palette silently took the other one down too.
 - The quick-actions palette (Ctrl+K) and the in-app project file manager were entirely hardcoded in English, ignoring the app's language setting.
 - The Backups page showed a "Database backups" tab (and tried to fetch backups for it) on native (containerless) projects, which have no database to back up, instead of hiding it the way the project's own details page already does.
+- Following an Elasticsearch, MinIO, RabbitMQ, or cron service's live log tail always failed with "Unsupported log service," even though starting/stopping, exec, log-clearing, and the terminal already worked fine for these services — the live-log allowlist was missing four entries every other per-service check already had.
+- Deleting an environment never removed its database, Redis, Elasticsearch, MinIO, or RabbitMQ data directories — only the generated Compose stack was cleaned up, leaving every deleted environment's engine data (database files, cache snapshots, search indices, object storage, message store) permanently orphaned on disk with no way to reclaim it through the UI.
 
 ### Security
 

--- a/src-tauri/src/container_logs.rs
+++ b/src-tauri/src/container_logs.rs
@@ -19,6 +19,10 @@ pub fn spawn(
         "mailpit",
         "adminer",
         "phpmyadmin",
+        "cron",
+        "elasticsearch",
+        "minio",
+        "rabbitmq",
     ];
     if service.is_some_and(|value| !SERVICES.contains(&value)) {
         return Err("Unsupported log service".into());

--- a/src-tauri/src/containers.rs
+++ b/src-tauri/src/containers.rs
@@ -106,6 +106,31 @@ pub fn delete(
             cleanup_errors.push(format!("generated stack: {error}"));
         }
     }
+    // Each service that persists its own state (the database engine, Redis,
+    // Elasticsearch, MinIO, RabbitMQ) gets a host directory bind-mounted into
+    // its container by `prepare()`, separate from the generated compose
+    // stack removed above — without cleaning these up too, every deleted
+    // environment leaves its database files, cache snapshots, search
+    // indices, object storage, and message store permanently orphaned on
+    // disk, with no UI path to reclaim them.
+    let service_directories = [
+        ("database", database_directory(app, id)),
+        ("redis", redis_directory(app, id)),
+        ("elasticsearch", elasticsearch_directory(app, id)),
+        ("minio", minio_directory(app, id)),
+        ("rabbitmq", rabbitmq_directory(app, id)),
+    ];
+    for (label, directory) in service_directories {
+        match directory {
+            Ok(directory) if directory.exists() => {
+                if let Err(error) = fs::remove_dir_all(directory) {
+                    cleanup_errors.push(format!("{label} data: {error}"));
+                }
+            }
+            Ok(_) => {}
+            Err(error) => cleanup_errors.push(format!("{label} data: {error}")),
+        }
+    }
     if let Err(error) = crate::backups::delete_all(app, id) {
         cleanup_errors.push(format!("database backups: {error}"));
     }


### PR DESCRIPTION
## Summary
Two unfinished-functionality gaps found while auditing for incomplete features (not new correctness bugs — the earlier bug-hunting passes this session are done):

- **`container_logs.rs`'s live-log `SERVICES` allowlist** was missing `cron`/`elasticsearch`/`minio`/`rabbitmq`, unlike the three equivalent 12-service allowlists elsewhere (`operate_service`, `service_context`, `terminal_context`). Start/stop, exec, log-clearing, and the terminal already worked for these services — only "follow logs" rejected them with "Unsupported log service".
- **`containers::delete()`** only ever removed the generated Compose stack directory, never the five per-service host directories `prepare()` creates for database/redis/elasticsearch/minio/rabbitmq engine state (confirmed via a repo-wide search: no `remove_dir_all` call site targets any of the five `*_directory()` helpers). Every deleted environment left its database files, cache snapshots, search indices, object storage, and message store permanently orphaned on disk.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (162 passed, 0 failed, 2 ignored)