### PR TITLE
Show a live terminal of project-scaffolding commands during creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings: an "About" section showing the app version, description, and author contact links (GitHub profile, repository, email).
 - One-click buttons to open MinIO's and RabbitMQ's web admin consoles from a project's Developer Tools card, matching the button Mailpit already had — the reverse-proxy routes for both already existed, just without a way to reach them.
 - A "Fallback command" field for Node.js projects (project wizard and environment editor) — it was already sent to the backend and used when the dev/start commands are both left empty, but had no UI to see or change it.
+- A terminal button next to the project wizard's progress bar during creation, showing — live, as they run — the exact `composer create-project`/wp-cli commands and their real output for WordPress, Laravel, and Symfony projects, plus a summary of which `.env` keys get set to connect to the provisioned database. Same idea as the dependency-installer's live command log, applied to project creation.
 
 ### Fixed
 

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -115,6 +115,68 @@ pub fn stream_stderr(
     }
 }
 
+/// Runs `child` to completion, calling `on_line` for each line of stdout and
+/// stderr as it's produced (interleaved, in whatever order the two streams
+/// actually deliver it) rather than only after the process exits — used
+/// where a caller wants to show the user a live terminal-style view of a
+/// long-running command instead of a spinner. `on_line` runs on whichever of
+/// the two reader threads produced that line, so it must be safe to call
+/// from either.
+pub fn stream_lines(
+    mut child: Child,
+    timeout: Duration,
+    label: &str,
+    on_line: impl Fn(&str) + Clone + Send + 'static,
+) -> Result<(ExitStatus, String, String), String> {
+    fn spawn_reader(
+        stream: Option<impl Read + Send + 'static>,
+        on_line: impl Fn(&str) + Send + 'static,
+    ) -> Option<thread::JoinHandle<String>> {
+        stream.map(|stream| {
+            thread::spawn(move || {
+                let mut captured = String::new();
+                for line in BufReader::new(stream).lines().map_while(Result::ok) {
+                    on_line(&line);
+                    captured.push_str(&line);
+                    captured.push('\n');
+                }
+                captured
+            })
+        })
+    }
+    let stdout_reader = spawn_reader(child.stdout.take(), on_line.clone());
+    let stderr_reader = spawn_reader(child.stderr.take(), on_line);
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() < timeout => thread::sleep(Duration::from_millis(50)),
+            Ok(None) => {
+                terminate(&mut child);
+                let _ = child.wait();
+                let _ = stdout_reader.and_then(|reader| reader.join().ok());
+                let _ = stderr_reader.and_then(|reader| reader.join().ok());
+                return Err(format!(
+                    "{label} timed out after {} seconds and was terminated",
+                    timeout.as_secs()
+                ));
+            }
+            Err(error) => {
+                terminate(&mut child);
+                let _ = child.wait();
+                return Err(format!("Failed while waiting for {label}: {error}"));
+            }
+        }
+    };
+    let stdout_text = stdout_reader
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    let stderr_text = stderr_reader
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    Ok((status, stdout_text, stderr_text))
+}
+
 pub(crate) fn terminate(child: &mut Child) {
     #[cfg(unix)]
     {
@@ -155,8 +217,40 @@ fn read_limited(reader: impl Read) -> std::io::Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{output, SHORT_TIMEOUT};
-    use std::{process::Command, time::Duration};
+    use super::{output, stream_lines, SHORT_TIMEOUT};
+    use std::{
+        process::{Command, Stdio},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    #[test]
+    fn stream_lines_delivers_each_line_live_and_still_returns_the_full_capture() {
+        // Regression test: the whole point of stream_lines over the plain
+        // output() above is that a caller (e.g. showing the user a live
+        // terminal view of a long-running install) sees each line as it's
+        // produced, not just a final blob once the process exits.
+        let child = Command::new("sh")
+            .args(["-c", "echo one; echo two >&2; echo three"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_for_callback = seen.clone();
+        let (status, stdout_text, stderr_text) =
+            stream_lines(child, SHORT_TIMEOUT, "test command", move |line| {
+                seen_for_callback.lock().unwrap().push(line.to_owned())
+            })
+            .unwrap();
+        assert!(status.success());
+        assert_eq!(stdout_text, "one\nthree\n");
+        assert_eq!(stderr_text, "two\n");
+        let mut lines = seen.lock().unwrap().clone();
+        lines.sort();
+        assert_eq!(lines, vec!["one", "three", "two"]);
+    }
 
     #[test]
     fn captures_command_output() {

--- a/src-tauri/src/project_export.rs
+++ b/src-tauri/src/project_export.rs
@@ -267,7 +267,7 @@ pub fn import(
             .find(|item| item.id == site_id)
             .cloned()
             .ok_or("Imported project was not found")?;
-        crate::project_templates::configure_duplicate(&imported_site, &environment)?;
+        crate::project_templates::configure_duplicate(app, &imported_site, &environment)?;
         Ok(created)
     })();
 

--- a/src-tauri/src/project_templates.rs
+++ b/src-tauri/src/project_templates.rs
@@ -7,9 +7,43 @@ use std::{
     process::{Command, Stdio},
 };
 
+use serde::Serialize;
+use tauri::Emitter;
+
 use crate::{containers::Environment, sites::Site};
 
 const SYMFONY_INSTALL_COMMAND: &str = "APP_ENV=dev COMPOSER_MEMORY_LIMIT=-1 composer create-project --no-interaction symfony/skeleton . && APP_ENV=dev composer require --no-interaction webapp";
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProvisionOutput {
+    environment_id: String,
+    line: String,
+}
+
+/// Shows the user exactly what LS Panel runs on their behalf while
+/// scaffolding a project — the same `composer create-project`/wp-cli
+/// commands (and, for the .env values it patches afterward, exactly which
+/// keys) a person would run by hand from a terminal. Secrets are redacted
+/// the same way any other environment output already is.
+fn emit_provision_line(
+    app: &tauri::AppHandle,
+    environment_id: &str,
+    line: &str,
+    secrets: &[String],
+) {
+    let clean = crate::security::redact(line, secrets.iter().cloned());
+    if clean.trim().is_empty() {
+        return;
+    }
+    let _ = app.emit(
+        "project-provision-output",
+        ProvisionOutput {
+            environment_id: environment_id.into(),
+            line: clean,
+        },
+    );
+}
 
 pub fn is_node_project(project_type: &str) -> bool {
     matches!(project_type, "node" | "react")
@@ -312,10 +346,14 @@ pub fn provision(
     }
 }
 
-pub fn configure_duplicate(site: &Site, environment: &Environment) -> Result<(), String> {
+pub fn configure_duplicate(
+    app: &tauri::AppHandle,
+    site: &Site,
+    environment: &Environment,
+) -> Result<(), String> {
     match site.project_type.as_str() {
-        "laravel" => configure_laravel_env(site, environment),
-        "symfony" => configure_symfony_env(site, environment),
+        "laravel" => configure_laravel_env(app, site, environment),
+        "symfony" => configure_symfony_env(app, site, environment),
         "wordpress" => {
             let path = Path::new(&site.directory).join("app").join("wp-config.php");
             let mut contents = fs::read_to_string(&path)
@@ -432,7 +470,7 @@ fn provision_laravel(
         96,
         "Configuring Laravel database",
     )?;
-    configure_laravel_env(site, environment)
+    configure_laravel_env(app, site, environment)
 }
 
 fn provision_symfony(
@@ -455,10 +493,14 @@ fn provision_symfony(
         96,
         "Configuring Symfony database",
     )?;
-    configure_symfony_env(site, environment)
+    configure_symfony_env(app, site, environment)
 }
 
-fn configure_laravel_env(site: &Site, environment: &Environment) -> Result<(), String> {
+fn configure_laravel_env(
+    app: &tauri::AppHandle,
+    site: &Site,
+    environment: &Environment,
+) -> Result<(), String> {
     let env_path = Path::new(&site.directory).join("app").join(".env");
     let mut contents = fs::read_to_string(&env_path)
         .map_err(|error| format!("Failed to read Laravel .env: {error}"))?;
@@ -467,7 +509,7 @@ fn configure_laravel_env(site: &Site, environment: &Environment) -> Result<(), S
     } else {
         "mysql"
     };
-    for (key, value) in [
+    let values = [
         ("APP_URL", format!("https://{}", site.domain)),
         ("DB_CONNECTION", driver.into()),
         ("DB_HOST", "database".into()),
@@ -482,13 +524,21 @@ fn configure_laravel_env(site: &Site, environment: &Environment) -> Result<(), S
         ("DB_DATABASE", environment.database_name.clone()),
         ("DB_USERNAME", environment.database_user.clone()),
         ("DB_PASSWORD", environment.database_password.clone()),
-    ] {
-        contents = set_env(contents, key, &value);
+    ];
+    for (key, value) in &values {
+        contents = set_env(contents, key, value);
     }
-    fs::write(env_path, contents).map_err(|error| format!("Failed to update Laravel .env: {error}"))
+    fs::write(&env_path, contents)
+        .map_err(|error| format!("Failed to update Laravel .env: {error}"))?;
+    emit_env_summary(app, environment, &values);
+    Ok(())
 }
 
-fn configure_symfony_env(site: &Site, environment: &Environment) -> Result<(), String> {
+fn configure_symfony_env(
+    app: &tauri::AppHandle,
+    site: &Site,
+    environment: &Environment,
+) -> Result<(), String> {
     let env_path = Path::new(&site.directory).join("app").join(".env");
     let mut contents = fs::read_to_string(&env_path)
         .map_err(|error| format!("Failed to read Symfony .env: {error}"))?;
@@ -503,8 +553,29 @@ fn configure_symfony_env(site: &Site, environment: &Environment) -> Result<(), S
             environment.database_user, environment.database_password, environment.database_name
         )
     };
-    contents = set_env(contents, "DATABASE_URL", &url);
-    fs::write(env_path, contents).map_err(|error| format!("Failed to update Symfony .env: {error}"))
+    let values = [("DATABASE_URL", url)];
+    for (key, value) in &values {
+        contents = set_env(contents, key, value);
+    }
+    fs::write(&env_path, contents)
+        .map_err(|error| format!("Failed to update Symfony .env: {error}"))?;
+    emit_env_summary(app, environment, &values);
+    Ok(())
+}
+
+fn emit_env_summary(app: &tauri::AppHandle, environment: &Environment, values: &[(&str, String)]) {
+    let secrets = crate::security::environment_secrets(app, &environment.id);
+    let summary = values
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    emit_provision_line(
+        app,
+        &environment.id,
+        &format!("# Updated app/.env: {summary}"),
+        &secrets,
+    );
 }
 
 fn run_in_php(
@@ -535,32 +606,46 @@ fn run_in_service(
         .filter(|_| status.running && status.compose_available)
         .ok_or(status.message)?;
     let workdir = format!("/var/www/sites/{}/app", site.name);
-    let output = crate::process::output(
-        crate::containers::runtime_command(&executable)
-            .args([
-                "compose",
-                "exec",
-                "-T",
-                "--workdir",
-                &workdir,
-                service,
-                "sh",
-                "-lc",
-                script,
-            ])
-            .current_dir(crate::containers::stack_directory(app, &environment.id)?)
-            .stdin(Stdio::null()),
+    let secrets = crate::security::environment_secrets(app, &environment.id);
+    emit_provision_line(app, &environment.id, &format!("$ {script}"), &secrets);
+    let mut command = crate::containers::runtime_command(&executable);
+    command
+        .args([
+            "compose",
+            "exec",
+            "-T",
+            "--workdir",
+            &workdir,
+            service,
+            "sh",
+            "-lc",
+            script,
+        ])
+        .current_dir(crate::containers::stack_directory(app, &environment.id)?)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let child = command
+        .spawn()
+        .map_err(|error| format!("Failed to launch project template installer: {error}"))?;
+    let live_app = app.clone();
+    let live_environment_id = environment.id.clone();
+    let live_secrets = secrets.clone();
+    let (status, stdout_text, stderr_text) = crate::process::stream_lines(
+        child,
         crate::process::INSTALL_TIMEOUT,
         "project template installer",
+        move |line| emit_provision_line(&live_app, &live_environment_id, line, &live_secrets),
     )?;
-    if output.status.success() {
+    if status.success() {
         Ok(())
     } else {
-        let detail = format!(
-            "{}{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
+        let detail = format!("{stdout_text}{stderr_text}");
         Err(detail.trim().to_owned())
     }
 }

--- a/src-tauri/src/site_commands.rs
+++ b/src-tauri/src/site_commands.rs
@@ -607,7 +607,7 @@ pub async fn duplicate_site(
                 .iter()
                 .find(|site| site.id == duplicate_site_id)
                 .ok_or("Duplicated project was not found")?;
-            project_templates::configure_duplicate(duplicated_site, &environment)?;
+            project_templates::configure_duplicate(&worker, duplicated_site, &environment)?;
             Ok(created)
         })();
 

--- a/src/features/project-wizard/project-wizard.tsx
+++ b/src/features/project-wizard/project-wizard.tsx
@@ -3,12 +3,20 @@ import { invoke } from "@tauri-apps/api/core"
 import { errorMessage } from "@/lib/errors"
 import { listen } from "@tauri-apps/api/event"
 import { open } from "@tauri-apps/plugin-dialog"
-import { ArrowLeft, ArrowRight, Check } from "lucide-react"
+import { ArrowLeft, ArrowRight, Check, TerminalSquare } from "lucide-react"
 
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Progress } from "@/components/ui/progress"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
 import { pickLanguage } from "@/i18n"
 import { WEB_SERVER_VERSIONS } from "@/lib/version-catalog"
 import type { Environment, Runtime, Site } from "@/types"
@@ -122,6 +130,8 @@ export function ProjectWizard({
     stage: text.preparingProject,
   })
   const [creationElapsed, setCreationElapsed] = React.useState(0)
+  const [provisionLines, setProvisionLines] = React.useState<string[]>([])
+  const provisionLogRef = React.useRef<HTMLDivElement>(null)
   const activeCreationEnvironment = React.useRef("")
   const creationStartedAt = React.useRef(0)
   const [error, setError] = React.useState("")
@@ -164,6 +174,21 @@ export function ProjectWizard({
       void unlisten.then((dispose) => dispose())
     }
   }, [text.buildingProject])
+  React.useEffect(() => {
+    const unlisten = listen<{ environmentId: string; line: string }>(
+      "project-provision-output",
+      ({ payload }) => {
+        if (payload.environmentId !== activeCreationEnvironment.current) return
+        setProvisionLines((current) => [...current.slice(-499), payload.line])
+      },
+    )
+    return () => {
+      void unlisten.then((dispose) => dispose())
+    }
+  }, [])
+  React.useEffect(() => {
+    provisionLogRef.current?.scrollTo({ top: provisionLogRef.current.scrollHeight })
+  }, [provisionLines])
   React.useEffect(() => {
     if (!environmentId && availableEnvironments[0]) setEnvironmentId(availableEnvironments[0].id)
   }, [environmentId, availableEnvironments])
@@ -226,6 +251,7 @@ export function ProjectWizard({
     creationStartedAt.current = Date.now()
     setCreationElapsed(0)
     setCreationProgress({ progress: 1, stage: text.preparingProject })
+    setProvisionLines([])
     setError("")
     const timestamp = Date.now()
     const id = `site-${timestamp}`
@@ -747,6 +773,46 @@ export function ProjectWizard({
               </div>
             )}
           </div>
+          {(busy || createdProjectId) && (
+            <Sheet>
+              <SheetTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="shrink-0"
+                    title={text.showTerminal}
+                  />
+                }
+              >
+                <TerminalSquare />
+              </SheetTrigger>
+              <SheetContent className="w-full min-w-0 sm:max-w-xl">
+                <SheetHeader>
+                  <SheetTitle>{text.showTerminal}</SheetTitle>
+                  <SheetDescription>{text.showTerminalDescription}</SheetDescription>
+                </SheetHeader>
+                <div className="min-h-0 flex-1 overflow-auto px-4 pb-4">
+                  <div
+                    ref={provisionLogRef}
+                    className="h-full min-h-96 overflow-auto rounded-lg bg-black p-3 font-mono text-xs text-zinc-200"
+                    aria-live="polite"
+                  >
+                    {provisionLines.length ? (
+                      provisionLines.map((line, index) => (
+                        <div key={`${index}-${line}`} className="whitespace-pre-wrap break-all">
+                          {line}
+                        </div>
+                      ))
+                    ) : (
+                      <span className="text-zinc-500">{text.waitingForOutput}</span>
+                    )}
+                  </div>
+                </div>
+              </SheetContent>
+            </Sheet>
+          )}
           {step < 6 ? (
             <Button className="shrink-0" disabled={!canContinue} onClick={next}>
               {text.continue}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -986,6 +986,10 @@ const en = {
     buildingProject: "Building project…",
     preparingProject: "Preparing project…",
     projectCreatedSuccessfully: "Project created successfully",
+    showTerminal: "Show terminal",
+    showTerminalDescription:
+      "The exact commands LS Panel runs to set up your project, live, as they happen.",
+    waitingForOutput: "Waiting for output…",
     selected: "Selected",
     inheritedEnvironmentSettings: "Inherited environment settings",
     inheritedEnvironmentDescription:

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -1032,6 +1032,10 @@ const uk: Dictionary = {
     buildingProject: "Побудова проєкту…",
     preparingProject: "Підготовка проєкту…",
     projectCreatedSuccessfully: "Проєкт успішно створено",
+    showTerminal: "Показати термінал",
+    showTerminalDescription:
+      "Точні команди, які LS Panel виконує для налаштування вашого проєкту — наживо, у міру виконання.",
+    waitingForOutput: "Очікування виводу…",
     selected: "Вибрано",
     inheritedEnvironmentSettings: "Успадковані налаштування середовища",
     inheritedEnvironmentDescription:


### PR DESCRIPTION
## Summary
Prompted by user feedback (a Reddit review) that it's not obvious LS Panel's WordPress/Laravel/Symfony scaffolding uses the same standard tools a person would run by hand — `composer create-project` with the official `laravel/laravel`/`symfony/skeleton` packages, a real `wordpress.org` download. Confirmed by reading the code that this is already true; the gap was visibility, not behavior. This surfaces it directly in the product instead of requiring a source dive.

- **`process.rs`**: new `stream_lines()` helper — runs a child process and calls back with each stdout/stderr line as it's produced (plus the full captured text once it exits, still needed for error messages), rather than only after the process exits like `output()` does. Generalizes the same live-reading approach `dependency_install.rs` already used privately for its own install-progress log.
- **`project_templates.rs`**: `run_in_service()` (the function every WordPress/Laravel/Symfony provisioning step already funnels through) now streams its command's output live via a new `project-provision-output` event instead of capturing silently and only surfacing it on failure. Emits the exact command line first, redacted the same way any other environment output already is. `configure_laravel_env()`/`configure_symfony_env()` (the `.env` patching step) now emit a summary line of exactly which keys got set, so that's visible too, not just the composer/wp-cli output.
- **`project-wizard.tsx`**: a terminal-icon button next to the creation progress bar opens a side panel showing these lines live as they arrive, styled like the existing dependency-installer's terminal log. Uses the same `environmentId` correlation + `listen()` pattern the wizard's existing `operation-progress` listener already relies on.

## Test plan
- [x] `cargo fmt`/`clippy`/`test` (170 passed, 0 failed — includes a new regression test for `stream_lines` confirming it delivers lines live via callback *and* still returns the full capture)
- [x] `npm run format:check`/`lint`/`test:frontend`/`tsc`/`vite build` all pass
- [ ] Not manually clicked through in a running GUI — this sandbox is headless (no display server), consistent with how frontend changes have been verified throughout this session. Verified instead via the isolated `stream_lines` unit test, full type-checking of the new Sheet/event wiring, and tracing that the event name and `environmentId` correlation key match exactly between the emitter and the `listen()` call.