### PR TITLE
Extend the live provisioning terminal to Git clone and native Node.js/React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings: an "About" section showing the app version, description, and author contact links (GitHub profile, repository, email).
 - One-click buttons to open MinIO's and RabbitMQ's web admin consoles from a project's Developer Tools card, matching the button Mailpit already had — the reverse-proxy routes for both already existed, just without a way to reach them.
 - A "Fallback command" field for Node.js projects (project wizard and environment editor) — it was already sent to the backend and used when the dev/start commands are both left empty, but had no UI to see or change it.
-- A terminal button next to the project wizard's progress bar during creation, showing — live, as they run — the exact `composer create-project`/wp-cli commands and their real output for WordPress, Laravel, and Symfony projects, plus a summary of which `.env` keys get set to connect to the provisioned database. Same idea as the dependency-installer's live command log, applied to project creation.
+- A terminal button next to the project wizard's progress bar during creation, showing — live, as they run — the exact `composer create-project`/wp-cli commands and their real output for WordPress, Laravel, and Symfony projects, plus a summary of which `.env` keys get set to connect to the provisioned database. Same idea as the dependency-installer's live command log, applied to project creation. Also covers cloning a Git repository (previously silent for up to an hour with no feedback at all) and, for native (containerless) Node.js/React projects, the `npm`/`pnpm install` and dev/start command.
 
 ### Fixed
 

--- a/src-tauri/src/project_templates.rs
+++ b/src-tauri/src/project_templates.rs
@@ -181,7 +181,12 @@ pub fn import_project(source: &Path, destination: &Path) -> Result<String, Strin
     Ok(detect_project_type(destination))
 }
 
-pub fn clone_project(repository: &str, destination: &Path) -> Result<String, String> {
+pub fn clone_project(
+    app: &tauri::AppHandle,
+    environment_id: &str,
+    repository: &str,
+    destination: &Path,
+) -> Result<String, String> {
     let repository = repository.trim();
     let valid = repository.starts_with("https://")
         || repository.starts_with("ssh://")
@@ -208,28 +213,50 @@ pub fn clone_project(repository: &str, destination: &Path) -> Result<String, Str
         return Err("The destination project directory is not empty".into());
     }
     let existed = destination.exists();
-    let output = crate::process::output(
-        Command::new("git")
-            .args(["clone", "--", repository])
-            .arg(destination)
-            .stdin(Stdio::null()),
+    let secrets = crate::security::environment_secrets(app, environment_id);
+    emit_provision_line(
+        app,
+        environment_id,
+        &format!("$ git clone -- {repository} {}", destination.display()),
+        &secrets,
+    );
+    let mut command = Command::new("git");
+    command
+        .args(["clone", "--progress", "--", repository])
+        .arg(destination)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let child = command
+        .spawn()
+        .map_err(|error| format!("Failed to launch Git clone: {error}"))?;
+    let live_app = app.clone();
+    let live_environment_id = environment_id.to_owned();
+    let live_secrets = secrets.clone();
+    let (status, _stdout_text, stderr_text) = crate::process::stream_lines(
+        child,
         crate::process::GIT_CLONE_TIMEOUT,
         "Git clone",
+        move |line| emit_provision_line(&live_app, &live_environment_id, line, &live_secrets),
     )
     .inspect_err(|_| {
         if !existed {
             let _ = fs::remove_dir_all(destination);
         }
     })?;
-    if !output.status.success() {
+    if !status.success() {
         if !existed {
             let _ = fs::remove_dir_all(destination);
         }
-        let detail = String::from_utf8_lossy(&output.stderr);
-        return Err(if detail.trim().is_empty() {
+        return Err(if stderr_text.trim().is_empty() {
             "Git clone failed".into()
         } else {
-            detail.trim().into()
+            stderr_text.trim().to_owned()
         });
     }
     Ok(detect_project_type(destination))

--- a/src-tauri/src/site_commands.rs
+++ b/src-tauri/src/site_commands.rs
@@ -156,7 +156,12 @@ pub async fn create_project_environment(
                 "Cloning and inspecting Git repository",
             )?;
             let repository = site.directory.clone();
-            site.project_type = project_templates::clone_project(&repository, &app_directory)?;
+            site.project_type = project_templates::clone_project(
+                &worker,
+                &environment.id,
+                &repository,
+                &app_directory,
+            )?;
         } else if matches!(
             site.project_type.as_str(),
             "wordpress" | "laravel" | "symfony" | "node" | "react"
@@ -379,7 +384,12 @@ pub async fn provision_site_in_environment(
                 "Cloning and inspecting Git repository",
             )?;
             let repository = site.directory.clone();
-            site.project_type = project_templates::clone_project(&repository, &app_directory)?;
+            site.project_type = project_templates::clone_project(
+                &worker,
+                &environment_id,
+                &repository,
+                &app_directory,
+            )?;
         } else if matches!(
             site.project_type.as_str(),
             "wordpress" | "laravel" | "symfony" | "react"

--- a/src/features/project-wizard/project-wizard.tsx
+++ b/src/features/project-wizard/project-wizard.tsx
@@ -187,6 +187,24 @@ export function ProjectWizard({
     }
   }, [])
   React.useEffect(() => {
+    // Native (containerless) Node.js/React projects have no
+    // composer/wp-cli-style provisioning step — their equivalent (an
+    // `npm`/`pnpm install`, and the dev/build/start command) already
+    // streams live through this same event the Logs page uses, so folding
+    // it into this same terminal panel covers them too instead of leaving
+    // them with nothing to show here.
+    const unlisten = listen<{ environmentId: string; source: string; line: string }>(
+      "environment-log-line",
+      ({ payload }) => {
+        if (payload.environmentId !== activeCreationEnvironment.current) return
+        setProvisionLines((current) => [...current.slice(-499), payload.line])
+      },
+    )
+    return () => {
+      void unlisten.then((dispose) => dispose())
+    }
+  }, [])
+  React.useEffect(() => {
     provisionLogRef.current?.scrollTo({ top: provisionLogRef.current.scrollHeight })
   }, [provisionLines])
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
Follow-up to the live provisioning terminal (only covered WordPress/Laravel/Symfony via composer/wp-cli). Two more project-creation paths run real commands with no visibility at all:

- **`clone_project()`** (the "git" project type) ran `git clone` through the plain blocking `process::output()` — completely silent for up to its full `GIT_CLONE_TIMEOUT` (1 hour) with zero feedback while cloning a large repository. Switched to the same `stream_lines()`-based pattern as `run_in_service()`, with `--progress` added to the git invocation (git suppresses its own progress output entirely once stdout/stderr aren't a TTY, so without this flag the live panel would show nothing).
- **Native (containerless) Node.js/React** projects already had live command output — `npm`/`pnpm install`, the dev/build/start command — streamed via the existing `environment-log-line` event the Logs page reads. The wizard's terminal panel now also listens for that event (same `environmentId` filter), so it shows up there too instead of only on a separate page.

**Scope note**: container-mode Node.js/React is *not* covered by either mechanism — its `npm`/`pnpm install` is baked directly into the node service's own compose command and runs as part of the container's entrypoint, not a process this app spawns. Capturing that would mean tailing `docker compose logs` instead, a materially different mechanism. The Logs page already does that for the running container; unifying it into this same panel would be a separate, larger piece of work.

## Test plan
- [x] `cargo fmt`/`clippy`/`test` (170 passed, 0 failed)
- [x] `npm run format:check`/`lint`/`test:frontend`/`tsc`/`vite build` all pass