### PR TITLE
Prepare v0.6.0-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0-beta] - 2026-08-13
+
 ### Added
 
 - Settings: an "About" section showing the app version, description, and author contact links (GitHub profile, repository, email).
@@ -232,7 +234,8 @@ Initial public beta.
 - Bilingual UI and documentation (English / Ukrainian).
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/bewdes/LSPanel/compare/v0.5.1-beta...HEAD
+[Unreleased]: https://github.com/bewdes/LSPanel/compare/v0.6.0-beta...HEAD
+[0.6.0-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.6.0-beta
 [0.5.1-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.5.1-beta
 [0.5.0-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.5.0-beta
 [0.4.0-beta]: https://github.com/bewdes/LSPanel/releases/tag/v0.4.0-beta

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lspanel",
   "private": true,
-  "version": "0.5.1-beta",
+  "version": "0.6.0-beta",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1978,7 +1978,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lspanel"
-version = "0.5.1-beta"
+version = "0.6.0-beta"
 dependencies = [
  "portable-pty",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lspanel"
-version = "0.5.1-beta"
+version = "0.6.0-beta"
 description = "Local server control panel"
 license = "Apache-2.0"
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LS Panel",
-  "version": "0.5.1-beta",
+  "version": "0.6.0-beta",
   "identifier": "dev.lspanel.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Version bump to 0.6.0-beta (minor — Unreleased contained `### Added` entries, so per SemVer this is a minor bump, not a patch) across `package.json`, `src-tauri/Cargo.toml`/`Cargo.lock`, and `src-tauri/tauri.conf.json`, plus moving the `[Unreleased]` CHANGELOG section under a dated `[0.6.0-beta]` heading.

Full change list is in CHANGELOG.md; highlights: the new live-terminal project-creation panel, native-site `.localhost` domains, a large batch of concurrency/race fixes, and remaining Russian-language error strings replaced.

## Test plan
- [x] `node scripts/check-version-sync.mjs` — versions in sync
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (170 passed)
- [x] `npm run check:frontend` (8/8 tests, build succeeds)
- [ ] After merge: tag `v0.6.0-beta` and push to trigger `.github/workflows/release.yml`