### PR TITLE
Fix cron terminal access and missing service pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The Terminal tab rejected a Cron service session with "Service cron is not enabled" even when Cron was configured — its availability check checked every other addable service but never special-cased Cron the way service start/stop/exec already did.
+- The default PHP welcome page's service pills never showed Elasticsearch, MinIO, or RabbitMQ, even when one of them was added to the environment, unlike Redis, Node.js, Mailpit, Adminer, and phpMyAdmin.
+
 ## [0.6.0-beta] - 2026-08-13
 
 ### Added

--- a/src-tauri/src/containers.rs
+++ b/src-tauri/src/containers.rs
@@ -925,6 +925,7 @@ pub fn terminal_context(
     let available = service == "web"
         || service == "database"
         || (service == "php" && environment.web_server == "Nginx")
+        || (service == "cron" && environment.php_cron)
         || environment
             .extra_services
             .iter()

--- a/src-tauri/src/sites.rs
+++ b/src-tauri/src/sites.rs
@@ -234,6 +234,9 @@ fn service_label(service: &str) -> Option<&'static str> {
         "mailpit" => Some("Mailpit"),
         "adminer" => Some("Adminer"),
         "phpmyadmin" => Some("phpMyAdmin"),
+        "elasticsearch" => Some("Elasticsearch"),
+        "minio" => Some("MinIO"),
+        "rabbitmq" => Some("RabbitMQ"),
         _ => None,
     }
 }
@@ -814,8 +817,8 @@ pub fn ensure_directories(app: &tauri::AppHandle, environment_id: &str) -> Resul
 #[cfg(test)]
 mod tests {
     use super::{
-        domains_overlap, seed_starter_files, validate_local_alias, validate_local_domain,
-        validate_project_name, write_react_starter, Environment, Site,
+        default_php_index, domains_overlap, seed_starter_files, validate_local_alias,
+        validate_local_domain, validate_project_name, write_react_starter, Environment, Site,
     };
     use std::fs;
 
@@ -854,6 +857,34 @@ mod tests {
         // DNS labels cap out at 63 characters.
         assert!(validate_project_name(&"a".repeat(63)).is_ok());
         assert!(validate_project_name(&"a".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn default_php_index_shows_a_pill_for_every_addable_extra_service() {
+        // Regression test: elasticsearch/minio/rabbitmq were addable extra
+        // services everywhere else in the app but silently dropped off the
+        // default PHP welcome page's service pills.
+        let site: Site = serde_json::from_str(
+            r#"{"id":"demo","name":"demo","domain":"demo.localhost","environmentId":"env-demo","directory":"/tmp/demo"}"#,
+        )
+        .unwrap();
+        let environment: Environment = serde_json::from_str(
+            r#"{"id":"env-demo","name":"env-demo","webServer":"Nginx","webVersion":"1.28","phpVersion":"8.4","database":"MariaDB","databaseVersion":"11.8","port":"8080","extraServices":["redis","node","mailpit","adminer","phpmyadmin","elasticsearch","minio","rabbitmq"]}"#,
+        )
+        .unwrap();
+        let html = default_php_index(&site, &environment);
+        for label in [
+            "Redis",
+            "Node.js",
+            "Mailpit",
+            "Adminer",
+            "phpMyAdmin",
+            "Elasticsearch",
+            "MinIO",
+            "RabbitMQ",
+        ] {
+            assert!(html.contains(label), "missing pill for {label}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `terminal_context`'s `available` gate (src-tauri/src/containers.rs) checked every addable extra service plus `web`/`database`/`php`, but never special-cased Cron the way `operate_service` and `service_context` already do — Cron isn't part of `extra_services` (it's the separate `environment.php_cron` boolean), so a Terminal session against a fully configured Cron service always failed with "Service cron is not enabled". Same allowlist-gap shape as the earlier per-service fixes (#29, #38, #64), just one gate deeper than the top-level `SERVICES` list those covered.
- `sites::service_label` (used to render the service pills on a project's default PHP welcome page) was missing Elasticsearch, MinIO, and RabbitMQ — Redis/Node.js/Mailpit/Adminer/phpMyAdmin got pills, the other three silently didn't.

Found via a targeted audit cross-referencing every per-service allowlist in the backend against the canonical addable-service list, prompted by the recurring pattern from prior PRs.

## Test plan
- [x] Added `default_php_index_shows_a_pill_for_every_addable_extra_service` regression test covering all 8 extra services.
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (171 passed)
- [x] `npm run check:frontend` (backend-only change, frontend untouched — ran for CI parity)