### PR TITLE
Offer Elasticsearch, MinIO, and RabbitMQ in the project wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Terminal tab rejected a Cron service session with "Service cron is not enabled" even when Cron was configured — its availability check checked every other addable service but never special-cased Cron the way service start/stop/exec already did.
 - The default PHP welcome page's service pills never showed Elasticsearch, MinIO, or RabbitMQ, even when one of them was added to the environment, unlike Redis, Node.js, Mailpit, Adminer, and phpMyAdmin.
+- The project wizard's "Additional services" step never offered Elasticsearch, MinIO, or RabbitMQ — only Redis, Mailpit, Adminer, and phpMyAdmin — even though every other part of the app (environment editor, validation, Compose generation, gateway routes, logs, terminal) has fully supported all three for several releases. Adding them required creating the project first, then editing the environment afterward.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src/features/project-wizard/components/steps/services-step.tsx
+++ b/src/features/project-wizard/components/steps/services-step.tsx
@@ -23,22 +23,24 @@ export function ServicesStep({
         <CardDescription>{text.additionalServicesDescription}</CardDescription>
       </CardHeader>
       <CardContent className="grid gap-2 sm:grid-cols-3">
-        {["redis", "mailpit", "adminer", "phpmyadmin"].map((service) => (
-          <label key={service} className="flex items-center gap-2 rounded-lg border p-3 text-sm">
-            <Checkbox
-              checked={services.includes(service)}
-              disabled={service === "phpmyadmin" && database === "PostgreSQL"}
-              onCheckedChange={() =>
-                setServices((current) =>
-                  current.includes(service)
-                    ? current.filter((item) => item !== service)
-                    : [...current, service],
-                )
-              }
-            />
-            {service}
-          </label>
-        ))}
+        {["redis", "mailpit", "adminer", "phpmyadmin", "elasticsearch", "minio", "rabbitmq"].map(
+          (service) => (
+            <label key={service} className="flex items-center gap-2 rounded-lg border p-3 text-sm">
+              <Checkbox
+                checked={services.includes(service)}
+                disabled={service === "phpmyadmin" && database === "PostgreSQL"}
+                onCheckedChange={() =>
+                  setServices((current) =>
+                    current.includes(service)
+                      ? current.filter((item) => item !== service)
+                      : [...current, service],
+                  )
+                }
+              />
+              {service}
+            </label>
+          ),
+        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
The project wizard's "Additional services" step (`src/features/project-wizard/components/steps/services-step.tsx`) only listed Redis, Mailpit, Adminer, and phpMyAdmin. Elasticsearch, MinIO, and RabbitMQ are fully supported everywhere else in the app — the environment editor's own service picker (`src/features/environment-window/constants.ts`), backend validation, Compose generation, gateway routing, live logs, and the terminal all already handle all three — but a user could only add them by creating the project first and then editing the environment afterward.

The wizard's `services` state flows straight into `buildEnvironmentPayload`'s `extraServices` field unmodified for container-mode environments (`src/features/project-wizard/helpers.ts:16`), so no other wiring was needed — just adding the three checkboxes.

## Test plan
- [x] `npm run check:frontend` (format, lint, 8/8 tests, tsc, build all pass)