### PR TITLE
Add the missing Redis eviction policy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Terminal tab rejected a Cron service session with "Service cron is not enabled" even when Cron was configured — its availability check checked every other addable service but never special-cased Cron the way service start/stop/exec already did.
 - The default PHP welcome page's service pills never showed Elasticsearch, MinIO, or RabbitMQ, even when one of them was added to the environment, unlike Redis, Node.js, Mailpit, Adminer, and phpMyAdmin.
 - The project wizard's "Additional services" step never offered Elasticsearch, MinIO, or RabbitMQ — only Redis, Mailpit, Adminer, and phpMyAdmin — even though every other part of the app (environment editor, validation, Compose generation, gateway routes, logs, terminal) has fully supported all three for several releases. Adding them required creating the project first, then editing the environment afterward.
+- The environment editor's Redis eviction policy dropdown only offered 5 of the 8 policies the backend actually accepts, missing `allkeys-random`, `volatile-lfu`, and `volatile-random`.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src/features/environment-window/components/tabs/services-tab.tsx
+++ b/src/features/environment-window/components/tabs/services-tab.tsx
@@ -296,7 +296,16 @@ export function ServicesTab({
           <Field label={text.evictionPolicyLabel}>
             <Choice
               value={draft.redisEvictionPolicy}
-              values={["noeviction", "allkeys-lru", "allkeys-lfu", "volatile-lru", "volatile-ttl"]}
+              values={[
+                "noeviction",
+                "allkeys-lru",
+                "allkeys-lfu",
+                "allkeys-random",
+                "volatile-lru",
+                "volatile-lfu",
+                "volatile-ttl",
+                "volatile-random",
+              ]}
               onChange={(value) => update("redisEvictionPolicy", value)}
             />
           </Field>


### PR DESCRIPTION
## Summary
The environment editor's Redis eviction policy `Choice` (`src/features/environment-window/components/tabs/services-tab.tsx`) only offered 5 values: `noeviction, allkeys-lru, allkeys-lfu, volatile-lru, volatile-ttl`. The backend (`src-tauri/src/container_validation.rs:315-327`) accepts 8: those 5 plus `allkeys-random`, `volatile-lfu`, `volatile-random`. Confirmed via `git show` that this list has been out of sync with the backend since the very first commit — not a recent regression, just never caught before.

## Test plan
- [x] `npm run check:frontend` (format, lint, 8/8 tests, tsc, build all pass)