### PR TITLE
Recover from a poisoned LiveLink tunnel-process lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default PHP welcome page's service pills never showed Elasticsearch, MinIO, or RabbitMQ, even when one of them was added to the environment, unlike Redis, Node.js, Mailpit, Adminer, and phpMyAdmin.
 - The project wizard's "Additional services" step never offered Elasticsearch, MinIO, or RabbitMQ — only Redis, Mailpit, Adminer, and phpMyAdmin — even though every other part of the app (environment editor, validation, Compose generation, gateway routes, logs, terminal) has fully supported all three for several releases. Adding them required creating the project first, then editing the environment afterward.
 - The environment editor's Redis eviction policy dropdown only offered 5 of the 8 policies the backend actually accepts, missing `allkeys-random`, `volatile-lfu`, and `volatile-random`.
+- LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src-tauri/src/tunnel_provider.rs
+++ b/src-tauri/src/tunnel_provider.rs
@@ -182,7 +182,7 @@ pub fn set_ngrok_authtoken(token: &str) -> Result<(), String> {
 }
 
 pub fn is_active(state: &TunnelProcesses, site_id: &str) -> bool {
-    let mut processes = state.0.lock().unwrap();
+    let mut processes = state.0.lock().unwrap_or_else(|error| error.into_inner());
     let Some(handle) = processes.get_mut(site_id) else {
         return false;
     };
@@ -204,14 +204,18 @@ pub fn public_url(
     if provider == "ngrok" {
         return ngrok_public_url(local_port);
     }
-    let processes = state.0.lock().unwrap();
-    processes
-        .get(site_id)
-        .and_then(|handle| handle.url.lock().unwrap().clone())
+    let processes = state.0.lock().unwrap_or_else(|error| error.into_inner());
+    processes.get(site_id).and_then(|handle| {
+        handle
+            .url
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    })
 }
 
 pub fn stop(state: &TunnelProcesses, site_id: &str) {
-    let mut processes = state.0.lock().unwrap();
+    let mut processes = state.0.lock().unwrap_or_else(|error| error.into_inner());
     if let Some(mut handle) = processes.remove(site_id) {
         crate::process::terminate(&mut handle.child);
         let _ = handle.child.wait();
@@ -219,7 +223,7 @@ pub fn stop(state: &TunnelProcesses, site_id: &str) {
 }
 
 pub fn stop_all(state: &TunnelProcesses) {
-    let mut processes = state.0.lock().unwrap();
+    let mut processes = state.0.lock().unwrap_or_else(|error| error.into_inner());
     for (_, mut handle) in processes.drain() {
         crate::process::terminate(&mut handle.child);
         let _ = handle.child.wait();
@@ -270,13 +274,17 @@ fn start_ngrok(
         child,
         url: Arc::new(Mutex::new(None)),
     };
-    state.0.lock().unwrap().insert(site_id.to_owned(), handle);
+    state
+        .0
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(site_id.to_owned(), handle);
     for _ in 0..20 {
         std::thread::sleep(Duration::from_millis(500));
         if let Some(url) = ngrok_public_url(local_port) {
-            let processes = state.0.lock().unwrap();
+            let processes = state.0.lock().unwrap_or_else(|error| error.into_inner());
             if let Some(handle) = processes.get(site_id) {
-                *handle.url.lock().unwrap() = Some(url);
+                *handle.url.lock().unwrap_or_else(|error| error.into_inner()) = Some(url);
             }
             return Ok(());
         }
@@ -397,7 +405,11 @@ fn start_cloudflare(
         child,
         url: Arc::clone(&url),
     };
-    state.0.lock().unwrap().insert(site_id.to_owned(), handle);
+    state
+        .0
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(site_id.to_owned(), handle);
     for _ in 0..10 {
         std::thread::sleep(Duration::from_millis(500));
         if is_active(state, site_id) {


### PR DESCRIPTION
## Summary
`tunnel_provider.rs` (LiveLink's ngrok/Cloudflare tunnel process registry) used a bare `.lock().unwrap()` at every call site (`is_active`, `public_url`, `stop`, `stop_all`, `start`) — 9 occurrences. If a panic ever occurred anywhere while one of these locks was held, the mutex would become poisoned and every subsequent `.unwrap()` on it would panic too, permanently breaking every LiveLink action for the rest of the session (or crashing the app, depending on which thread hit it).

Every other lock in the codebase already recovers from poisoning via `.unwrap_or_else(|error| error.into_inner())` (`containers.rs`, `tls.rs`, `auto_heal_monitor.rs`, `auto_stop_monitor.rs`, `git_status_monitor.rs`) — even this same file's own `Drop` impl already does `if let Ok(mut processes) = self.0.lock()`. The 9 other call sites were the one inconsistent holdout, apparently just missed when the recovery pattern was adopted elsewhere.

Found via a project-wide grep for `.lock()` usage, comparing every call site's poisoning behavior against the rest of the codebase's established convention.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (171 passed)