### PR TITLE
Show a clear message when Mailpit's environment isn't running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The project wizard's "Additional services" step never offered Elasticsearch, MinIO, or RabbitMQ — only Redis, Mailpit, Adminer, and phpMyAdmin — even though every other part of the app (environment editor, validation, Compose generation, gateway routes, logs, terminal) has fully supported all three for several releases. Adding them required creating the project first, then editing the environment afterward.
 - The environment editor's Redis eviction policy dropdown only offered 5 of the 8 policies the backend actually accepts, missing `allkeys-random`, `volatile-lfu`, and `volatile-random`.
 - LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
+- The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a clear explanation when its environment wasn't running.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The project wizard's "Additional services" step never offered Elasticsearch, MinIO, or RabbitMQ — only Redis, Mailpit, Adminer, and phpMyAdmin — even though every other part of the app (environment editor, validation, Compose generation, gateway routes, logs, terminal) has fully supported all three for several releases. Adding them required creating the project first, then editing the environment afterward.
 - The environment editor's Redis eviction policy dropdown only offered 5 of the 8 policies the backend actually accepts, missing `allkeys-random`, `volatile-lfu`, and `volatile-random`.
 - LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
-- The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a clear explanation when its environment wasn't running.
+- The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src-tauri/src/mailpit.rs
+++ b/src-tauri/src/mailpit.rs
@@ -152,8 +152,22 @@ fn request(
             ],
         )
     };
-    let output = crate::containers::execute_service_command(app, environment_id, service, command)?;
+    let output = crate::containers::execute_service_command(app, environment_id, service, command)
+        .map_err(friendly_service_error)?;
     parse_response(&output, expect_json)
+}
+
+/// `execute_service_command` surfaces the container runtime's own raw error
+/// (e.g. `service "web" is not running`) when the target service isn't up —
+/// clear enough for the Terminal/exec-command features where the user chose
+/// to run a command against a specific service, but confusing on the Mail
+/// page, which never mentions a "web" service at all.
+fn friendly_service_error(error: String) -> String {
+    if error.contains("is not running") {
+        "Mailpit is unavailable because the environment isn't running. Start the environment to view mail.".into()
+    } else {
+        error
+    }
 }
 
 fn parse_response(output: &str, expect_json: bool) -> Result<Value, String> {
@@ -243,7 +257,7 @@ fn valid_email(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_response, valid_email, validate_id};
+    use super::{friendly_service_error, parse_response, valid_email, validate_id};
 
     #[test]
     fn message_ids_cannot_escape_api_paths() {
@@ -267,6 +281,14 @@ mod tests {
         let error = parse_response("__LSP_MAILPIT_RESPONSE__404:bm90IGZvdW5k", false).unwrap_err();
         assert!(error.contains("HTTP 404"));
         assert!(error.contains("not found"));
+    }
+
+    #[test]
+    fn a_stopped_service_reports_a_clear_reason_instead_of_a_raw_compose_error() {
+        let error = friendly_service_error(r#"service "web" is not running"#.into());
+        assert!(error.contains("environment isn't running"));
+        let other = friendly_service_error("some other failure".into());
+        assert_eq!(other, "some other failure");
     }
 
     #[test]

--- a/src/features/mail/mail-page.tsx
+++ b/src/features/mail/mail-page.tsx
@@ -64,15 +64,21 @@ type MailText = Dictionary["mail"]
 
 export function MailPage({
   environments,
+  states,
   language,
 }: {
   environments: Environment[]
+  states: Record<string, string>
   language: string
 }) {
   const text = pickLanguage(language).mail
   const available = React.useMemo(
     () => environments.filter((environment) => environment.extraServices?.includes("mailpit")),
     [environments],
+  )
+  const runningAvailable = React.useMemo(
+    () => available.filter((environment) => states[environment.id] === "running"),
+    [available, states],
   )
   const [messages, setMessages] = React.useState<MailSummary[]>([])
   const [selected, setSelected] = React.useState<MailDetail | null>(null)
@@ -85,7 +91,10 @@ export function MailPage({
 
   const refresh = React.useCallback(
     async (options?: { silent?: boolean }) => {
-      if (!available.length) return
+      if (!runningAvailable.length) {
+        setMessages([])
+        return
+      }
       const silent = options?.silent ?? false
       if (!silent) {
         setBusy(true)
@@ -94,7 +103,7 @@ export function MailPage({
       }
       try {
         const responses = await Promise.allSettled(
-          available.map(async (environment) => {
+          runningAvailable.map(async (environment) => {
             const response = await invoke<unknown>("list_mailpit_messages", {
               environmentId: environment.id,
             })
@@ -115,7 +124,7 @@ export function MailPage({
         if (!silent) setBusy(false)
       }
     },
-    [available],
+    [runningAvailable],
   )
 
   React.useEffect(() => {
@@ -125,10 +134,10 @@ export function MailPage({
   }, [refresh])
 
   React.useEffect(() => {
-    if (!available.length) return
+    if (!runningAvailable.length) return
     const timer = window.setInterval(() => void refresh({ silent: true }), 10000)
     return () => window.clearInterval(timer)
-  }, [refresh, available.length])
+  }, [refresh, runningAvailable.length])
 
   const mailboxes = React.useMemo(
     () =>
@@ -215,12 +224,12 @@ export function MailPage({
       ),
   )
   const mailboxEnvironment =
-    available.find(
+    runningAvailable.find(
       (item) =>
         item.id ===
         (selected?.environmentId ??
           messages.find((message) => message.recipients.includes(mailbox))?.environmentId),
-    ) ?? available[0]
+    ) ?? runningAvailable[0]
 
   return (
     <div>
@@ -243,7 +252,7 @@ export function MailPage({
             )}
             <Button
               variant="outline"
-              disabled={busy || !available.length}
+              disabled={busy || !runningAvailable.length}
               onClick={() => void refresh()}
             >
               <RefreshCw className={busy ? "animate-spin" : ""} /> {text.refresh}
@@ -252,7 +261,7 @@ export function MailPage({
         }
       />
       <div className="grid gap-4 px-4 pb-6 lg:px-6">
-        {available.length > 0 ? (
+        {runningAvailable.length > 0 ? (
           <>
             <div className="flex flex-wrap gap-2">
               <Select
@@ -347,8 +356,17 @@ export function MailPage({
             <CardContent className="grid min-h-64 place-items-center text-center">
               <div>
                 <Mail className="mx-auto mb-3 size-9 text-muted-foreground" />
-                <p className="font-medium">{text.mailpitNotEnabled}</p>
-                <p className="text-sm text-muted-foreground">{text.enableMailpitHint}</p>
+                {available.length > 0 ? (
+                  <>
+                    <p className="font-medium">{text.mailboxesStopped}</p>
+                    <p className="text-sm text-muted-foreground">{text.startEnvironmentHint}</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="font-medium">{text.mailpitNotEnabled}</p>
+                    <p className="text-sm text-muted-foreground">{text.enableMailpitHint}</p>
+                  </>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -676,6 +676,8 @@ const en = {
     inboxEmpty: "Inbox is empty.",
     mailpitNotEnabled: "Mailpit is not enabled",
     enableMailpitHint: "Enable Mailpit in an environment to capture local email.",
+    mailboxesStopped: "No mail to show right now",
+    startEnvironmentHint: "Start the environment to view and send mail through Mailpit.",
     selectMessageToPreview: "Select a message to preview it.",
     resend: "Resend",
     delete: "Delete",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -727,6 +727,8 @@ const uk: Dictionary = {
     inboxEmpty: "Вхідні порожні.",
     mailpitNotEnabled: "Mailpit не увімкнено",
     enableMailpitHint: "Увімкніть Mailpit у середовищі, щоб перехоплювати локальну пошту.",
+    mailboxesStopped: "Наразі немає пошти для показу",
+    startEnvironmentHint: "Запустіть середовище, щоб переглядати й надсилати пошту через Mailpit.",
     selectMessageToPreview: "Виберіть лист для перегляду.",
     resend: "Повторно надіслати",
     delete: "Видалити",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -382,7 +382,9 @@ function App() {
                 {view === "logs" && (
                   <LogsPage sites={sites} environments={environments} language={language} />
                 )}
-                {view === "mail" && <MailPage environments={environments} language={language} />}
+                {view === "mail" && (
+                  <MailPage environments={environments} states={states} language={language} />
+                )}
                 {view === "backups" && (
                   <BackupsPage sites={sites} environments={environments} language={language} />
                 )}


### PR DESCRIPTION
## Summary
Reported by the user: with all containers stopped, the Mail page showed the raw error `service "web" is not running` — duplicated, since each mailpit-enabled environment fails independently and the frontend joins all failures into one error banner. The user also flagged that the fix needs to be localized, not a raw English error, and suggested a simple "no mail" placeholder instead of an error state.

Root cause: `mailpit.rs::request()` reaches Mailpit's HTTP API by execing into the environment's `web`/`php`/`node` service via `containers::execute_service_command`, which shells out to `compose exec`. When the target service isn't running, Compose's own raw stderr (`service "web" is not running` — confirmed exact wording by reproducing it locally with a real stopped Compose service) passed straight through to the user with no context, and wasn't localized since raw backend `Result` strings aren't part of the i18n system in this codebase (only notifications are, via `send_localized`).

Two-part fix:
- **Backend** (`mailpit.rs`): added `friendly_service_error()` as a defense-in-depth fallback, replacing the raw compose error with a clear English explanation if this path is ever hit despite the frontend change below (e.g. an environment stopping mid-request).
- **Frontend** (`mail-page.tsx`, `main.tsx`, `en.ts`/`uk.ts`): the Mail page now receives the same `states` (environment running-state) map already used elsewhere, filters to only actually-running mailpit-enabled environments before ever attempting to fetch mail, and shows a calm, localized "no mail to show right now" placeholder (matching the existing "Mailpit not enabled" empty-state style) for the common case of a stopped environment — never hitting the error path or the backend at all.

## Test plan
- [x] Added `a_stopped_service_reports_a_clear_reason_instead_of_a_raw_compose_error` regression test.
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (172 passed)
- [x] `prettier --check`, `eslint`, `tsc --noEmit`, `vite build`, and `test:frontend` (8/8) on the changed files
