### PR TITLE
Preview language and theme changes live in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The environment editor's Redis eviction policy dropdown only offered 5 of the 8 policies the backend actually accepts, missing `allkeys-random`, `volatile-lfu`, and `volatile-random`.
 - LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
 - The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
+- Changing the language or theme in Settings only took effect app-wide (sidebar, every page) after clicking Save — both now preview live as soon as you pick them, while every other setting still waits for Save as before.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src/features/settings/settings-page.tsx
+++ b/src/features/settings/settings-page.tsx
@@ -142,9 +142,15 @@ export function SettingsPage({
                 <Field label={text.languageLabel}>
                   <Select
                     value={draft.language}
-                    onValueChange={(value) =>
-                      value && setDraft({ ...draft, language: String(value) })
-                    }
+                    onValueChange={(value) => {
+                      if (!value) return
+                      setDraft((current) => ({ ...current, language: String(value) }))
+                      // Language and theme are pure presentation, so preview
+                      // them app-wide immediately instead of waiting for
+                      // Save — unlike every other setting here, which can
+                      // have a real side effect once persisted.
+                      onChange({ ...settings, language: String(value) })
+                    }}
                   >
                     <SelectTrigger className="w-full">
                       <SelectValue />
@@ -161,7 +167,12 @@ export function SettingsPage({
                 <Field label={text.themeLabel}>
                   <Select
                     value={draft.theme}
-                    onValueChange={(value) => value && setDraft({ ...draft, theme: String(value) })}
+                    onValueChange={(value) => {
+                      if (!value) return
+                      setDraft((current) => ({ ...current, theme: String(value) }))
+                      onChange({ ...settings, theme: String(value) })
+                      applyTheme(String(value))
+                    }}
                   >
                     <SelectTrigger className="w-full">
                       <SelectValue />


### PR DESCRIPTION
## Summary
Reported by the user: changing the language in Settings didn't update the sidebar (or anything else app-wide) until clicking Save. Root cause: the language `Select`'s `onValueChange` only called `setDraft(...)`, updating the Settings page's own local edit buffer — the app-wide `language` used everywhere else (`src/main.tsx:167`, `const language = settings.language`) only changes when `save()` calls `onChange(saved)` after the backend confirms the save.

The theme select has the exact same shape and the same bug (confirmed by reading the code, not just guessing) — `applyTheme()` was likewise only called from `save()`.

Fix: both selects now also call `onChange({ ...settings, language/theme: value })` immediately, based on `settings` (the last-saved state) rather than `draft`, so any other unsaved edits elsewhere on the page don't leak into the live app state early. Save still persists the full draft exactly as before — this only makes these two purely-presentational fields preview live, the way a user would expect from a language/theme picker.

## Test plan
- [x] `prettier --check`, `eslint`, `tsc --noEmit`, `test:frontend` (8/8), `vite build` all pass
