### PR TITLE
Stream database readiness/creation into the wizard's live terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
 - The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
 - Changing the language or theme in Settings only took effect app-wide (sidebar, every page) after clicking Save — both now preview live as soon as you pick them, while every other setting still waits for Save as before.
+- The project wizard's live terminal went silent for the entire "waiting for the database to accept connections" phase during container-mode creation — often the single longest wait, especially on a fresh MySQL/MariaDB data directory — showing only a static progress-bar label instead of the actual readiness checks and the database/user creation commands.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src-tauri/src/container_bootstrap.rs
+++ b/src-tauri/src/container_bootstrap.rs
@@ -48,6 +48,13 @@ pub(crate) fn ensure_database(
     directory: &Path,
     environment: &Environment,
 ) -> Result<(), String> {
+    let secrets = crate::security::environment_secrets(app, id);
+    crate::operations::emit_provision_line(
+        app,
+        id,
+        "$ Waiting for the database service to accept connections…",
+        &secrets,
+    );
     let mut ready = false;
     let mut last_error = String::new();
     // A fresh MySQL/MariaDB data directory can take considerably longer than
@@ -105,6 +112,12 @@ pub(crate) fn ensure_database(
                     (attempt + 1) * 2
                 ),
             );
+            crate::operations::emit_provision_line(
+                app,
+                id,
+                &format!("… still waiting ({}s)", (attempt + 1) * 2),
+                &secrets,
+            );
         }
         thread::sleep(Duration::from_secs(2));
     }
@@ -136,10 +149,12 @@ pub(crate) fn ensure_database(
         } else {
             "No database logs were returned".into()
         };
+        crate::operations::emit_provision_line(app, id, &detail, &secrets);
         return Err(format!(
             "Database service did not become ready within 120 seconds.\n{detail}"
         ));
     }
+    crate::operations::emit_provision_line(app, id, "Database service is ready.", &secrets);
     // The project wizard's "Automatically create database" toggle is stored
     // as an environment variable rather than a dedicated field; honor it
     // here instead of always creating the database regardless of the user's
@@ -192,11 +207,20 @@ pub(crate) fn ensure_database(
             environment.database_user.clone(),
             environment.database_name.clone(),
         ];
+        crate::operations::emit_provision_line(
+            app,
+            id,
+            &format!("$ {}", create_args.join(" ")),
+            &secrets,
+        );
         let output = compose_exec(executable, directory, &create_args)?;
         return if output.status.success() {
+            crate::operations::emit_provision_line(app, id, "Database created.", &secrets);
             Ok(())
         } else {
-            Err(String::from_utf8_lossy(&output.stderr).trim().to_owned())
+            let error = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            crate::operations::emit_provision_line(app, id, &error, &secrets);
+            Err(error)
         };
     }
 
@@ -218,11 +242,15 @@ pub(crate) fn ensure_database(
         "-e".into(),
         sql,
     ];
+    crate::operations::emit_provision_line(app, id, &format!("$ {}", args.join(" ")), &secrets);
     let output = compose_exec(executable, directory, &args)?;
     if output.status.success() {
+        crate::operations::emit_provision_line(app, id, "Database and user created.", &secrets);
         Ok(())
     } else {
-        Err(String::from_utf8_lossy(&output.stderr).trim().to_owned())
+        let error = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        crate::operations::emit_provision_line(app, id, &error, &secrets);
+        Err(error)
     }
 }
 


### PR DESCRIPTION
## Summary
Reported by the user: project creation's live terminal panel doesn't show everything from 0% to 100%.

Traced every step of `create_project_environment`'s 0→100% sequence to find every point that runs an external command without emitting to `project-provision-output`. The dominant gap by far: `container_bootstrap.rs::ensure_database` polls the database service for readiness (up to 120s, and the existing code comment already notes "a fresh MySQL/MariaDB data directory can take considerably longer than 30 seconds") and then runs the actual `CREATE DATABASE`/`CREATE USER` commands — all of it silent in the terminal panel, only updating the progress bar's static stage text ("Waiting for database initialization (Ns)"). For most container-mode projects this is the single longest wait in the whole creation flow, so it's the part users are most likely to notice showing nothing.

Fixed: `ensure_database` now emits the same `$ ...` / output lines every other provisioning step already does — the readiness check starting, periodic "still waiting" pings at the same cadence as the progress bar, the failure detail on timeout, a ready confirmation, and the actual database/user creation command and its result. Secrets are redacted the same way as everywhere else (`security::environment_secrets` + `emit_provision_line`).

**Two smaller, lower-impact silent spots I found but left alone** (happy to fix if you want literal 100% coverage): the local HTTPS gateway's own `compose up`/`down` restart (~1-2s, shared across all environments so attributing it to one wizard session would need a signature change) and `git init` when auto-init is on (near-instant). Also SQL dump import during creation (only relevant if you use that specific wizard option) — its underlying command has stdout suppressed already, so there's little to show beyond a start/end line.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (172 passed)