### PR TITLE
Replace the wizard's step progress bar with a segmented indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The project wizard's step-navigation indicator is now a segmented bar (one segment per step) instead of a continuous percentage bar — clearer at a glance how many steps remain, since step count varies by project type and runtime mode.
+
 ### Fixed
 
 - The Terminal tab rejected a Cron service session with "Service cron is not enabled" even when Cron was configured — its availability check checked every other addable service but never special-cased Cron the way service start/stop/exec already did.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LiveLink's tunnel-process lock could panic (crashing every subsequent LiveLink action for the rest of the session) instead of recovering, if it was ever poisoned by a panic elsewhere — every other lock in the app already recovers from poisoning, this one was missed.
 - The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
 - Changing the language or theme in Settings only took effect app-wide (sidebar, every page) after clicking Save — both now preview live as soon as you pick them, while every other setting still waits for Save as before.
+- The project wizard's live terminal went silent for the entire "waiting for the database to accept connections" phase during container-mode creation — often the single longest wait, especially on a fresh MySQL/MariaDB data directory — showing only a static progress-bar label instead of the actual readiness checks and the database/user creation commands.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src-tauri/src/container_bootstrap.rs
+++ b/src-tauri/src/container_bootstrap.rs
@@ -48,6 +48,13 @@ pub(crate) fn ensure_database(
     directory: &Path,
     environment: &Environment,
 ) -> Result<(), String> {
+    let secrets = crate::security::environment_secrets(app, id);
+    crate::operations::emit_provision_line(
+        app,
+        id,
+        "$ Waiting for the database service to accept connections…",
+        &secrets,
+    );
     let mut ready = false;
     let mut last_error = String::new();
     // A fresh MySQL/MariaDB data directory can take considerably longer than
@@ -105,6 +112,12 @@ pub(crate) fn ensure_database(
                     (attempt + 1) * 2
                 ),
             );
+            crate::operations::emit_provision_line(
+                app,
+                id,
+                &format!("… still waiting ({}s)", (attempt + 1) * 2),
+                &secrets,
+            );
         }
         thread::sleep(Duration::from_secs(2));
     }
@@ -136,10 +149,12 @@ pub(crate) fn ensure_database(
         } else {
             "No database logs were returned".into()
         };
+        crate::operations::emit_provision_line(app, id, &detail, &secrets);
         return Err(format!(
             "Database service did not become ready within 120 seconds.\n{detail}"
         ));
     }
+    crate::operations::emit_provision_line(app, id, "Database service is ready.", &secrets);
     // The project wizard's "Automatically create database" toggle is stored
     // as an environment variable rather than a dedicated field; honor it
     // here instead of always creating the database regardless of the user's
@@ -192,11 +207,20 @@ pub(crate) fn ensure_database(
             environment.database_user.clone(),
             environment.database_name.clone(),
         ];
+        crate::operations::emit_provision_line(
+            app,
+            id,
+            &format!("$ {}", create_args.join(" ")),
+            &secrets,
+        );
         let output = compose_exec(executable, directory, &create_args)?;
         return if output.status.success() {
+            crate::operations::emit_provision_line(app, id, "Database created.", &secrets);
             Ok(())
         } else {
-            Err(String::from_utf8_lossy(&output.stderr).trim().to_owned())
+            let error = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            crate::operations::emit_provision_line(app, id, &error, &secrets);
+            Err(error)
         };
     }
 
@@ -218,11 +242,15 @@ pub(crate) fn ensure_database(
         "-e".into(),
         sql,
     ];
+    crate::operations::emit_provision_line(app, id, &format!("$ {}", args.join(" ")), &secrets);
     let output = compose_exec(executable, directory, &args)?;
     if output.status.success() {
+        crate::operations::emit_provision_line(app, id, "Database and user created.", &secrets);
         Ok(())
     } else {
-        Err(String::from_utf8_lossy(&output.stderr).trim().to_owned())
+        let error = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        crate::operations::emit_provision_line(app, id, &error, &secrets);
+        Err(error)
     }
 }
 

--- a/src/features/project-wizard/project-wizard.tsx
+++ b/src/features/project-wizard/project-wizard.tsx
@@ -462,9 +462,18 @@ export function ProjectWizard({
           <div className="grid gap-2">
             <div className="flex justify-between text-xs text-muted-foreground">
               <span>{steps[step]}</span>
-              <span>{Math.round(((step + 1) / steps.length) * 100)}%</span>
+              <span>{text.stepOf(step + 1, steps.length)}</span>
             </div>
-            <Progress value={((step + 1) / steps.length) * 100} />
+            <div className="flex gap-1">
+              {steps.map((label, index) => (
+                <div
+                  key={label}
+                  className={`h-1.5 flex-1 rounded-full ${
+                    index <= step ? "bg-primary" : "bg-primary/15"
+                  }`}
+                />
+              ))}
+            </div>
           </div>
           {executionMode !== "native" && runtime && !runtime.composeAvailable && (
             <Alert variant="destructive">


### PR DESCRIPTION
## Summary
Requested by the user: replace the wizard's top step-navigation progress bar (percentage-based, `src/features/project-wizard/project-wizard.tsx`) with a segmented/dashed line — one segment per step, filled up to the current step.

Note: this is the *step-navigation* indicator only (Type → Basics → ... → Review), not the separate 0–100% *creation* progress bar shown later while the project is actually being built (`<Progress value={creationProgress.progress} .../>`), which is a genuine percentage of real work and stays as a continuous bar.

The label row above it now shows "Step X of N" (reusing the existing `text.stepOf` already used in the header) instead of a raw percentage, since a percentage doesn't map cleanly onto discrete segments.

## Test plan
- [x] `prettier --check`, `eslint`, `tsc --noEmit`, `test:frontend` (8/8), `vite build` all pass