### PR TITLE
Remove the stale "Beta 0.1" version reference from the domain hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
 - Changing the language or theme in Settings only took effect app-wide (sidebar, every page) after clicking Save — both now preview live as soon as you pick them, while every other setting still waits for Save as before.
 - The project wizard's live terminal went silent for the entire "waiting for the database to accept connections" phase during container-mode creation — often the single longest wait, especially on a fresh MySQL/MariaDB data directory — showing only a static progress-bar label instead of the actual readiness checks and the database/user creation commands.
+- The project wizard's local-domain hint still said "Beta 0.1 uses domains ending in .localhost," a stale reference to a version from long before the current one.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Mail page showed a raw `service "web" is not running` container-runtime error (once per stopped mailbox, so often duplicated) instead of a calm, localized "no mail to show" placeholder when a mailbox's environment wasn't running — it no longer even attempts to fetch mail for stopped environments.
 - Changing the language or theme in Settings only took effect app-wide (sidebar, every page) after clicking Save — both now preview live as soon as you pick them, while every other setting still waits for Save as before.
 - The project wizard's live terminal went silent for the entire "waiting for the database to accept connections" phase during container-mode creation — often the single longest wait, especially on a fresh MySQL/MariaDB data directory — showing only a static progress-bar label instead of the actual readiness checks and the database/user creation commands.
-- The project wizard's local-domain hint still said "Beta 0.1 uses domains ending in .localhost," a stale reference to a version from long before the current one.
+- The project wizard's local-domain hint still said "Beta 0.1 uses domains ending in .localhost," a stale reference to a version from long before the current one — the same stale reference also appeared in the backend's own domain-validation error message.
 
 ## [0.6.0-beta] - 2026-08-13
 

--- a/src-tauri/src/sites.rs
+++ b/src-tauri/src/sites.rs
@@ -522,7 +522,7 @@ pub(crate) fn validate_local_domain(domain: &str) -> Result<(), String> {
         return Err("Enter a valid domain without protocol or path".into());
     }
     if !domain.ends_with(".localhost") {
-        return Err("Beta 0.1 supports only domains ending in .localhost".into());
+        return Err("Only domains ending in .localhost are supported".into());
     }
     if domain.len() > 253
         || domain.split('.').any(|label| {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -844,7 +844,7 @@ const en = {
     nameLabel: "Name",
     nameHint: "Letters, digits, hyphens and underscores.",
     localDomainLabel: "Local domain",
-    domainHint: "Beta 0.1 uses domains ending in .localhost.",
+    domainHint: "Must end in .localhost.",
     directoryLabel: "Directory",
     domainTaken: "This domain is already used.",
     nameTaken: "A project with this name already exists.",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -891,7 +891,7 @@ const uk: Dictionary = {
     nameLabel: "Назва",
     nameHint: "Літери, цифри, дефіси та підкреслення.",
     localDomainLabel: "Локальний домен",
-    domainHint: "У Beta 0.1 домени закінчуються на .localhost.",
+    domainHint: "Має закінчуватися на .localhost.",
     directoryLabel: "Каталог",
     domainTaken: "Цей домен уже використовується.",
     nameTaken: "Проєкт із такою назвою вже існує.",


### PR DESCRIPTION
## Summary
Reported by the user (found in `src/i18n/locales/uk.ts`): the project wizard's local-domain field hint said "У Beta 0.1 домени закінчуються на .localhost." / "Beta 0.1 uses domains ending in .localhost." — a hardcoded reference to a version from long before the current one (0.6.0-beta). The fact itself (domains end in `.localhost`) has been true since the beginning and isn't tied to any specific version, so the fix just drops the stale version qualifier instead of updating it to another number that would go stale again.

Grepped for any other hardcoded version-number references in UI copy — this was the only one.

## Test plan
- [x] `prettier --check`, `eslint`, `tsc --noEmit`, `test:frontend` (8/8) all pass