### PR TITLE
Transliterate Cyrillic project names instead of rejecting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The project wizard's step-navigation indicator is now a segmented bar (one segment per step) instead of a continuous percentage bar — clearer at a glance how many steps remain, since step count varies by project type and runtime mode.
 
+### Added
+
+- The project wizard's Name field transliterates Cyrillic input into a Latin slug as you type instead of rejecting it — the underlying project name has to stay ASCII (it becomes the Docker container name prefix, the `.localhost` domain label, and the project's directory name), so typing a Ukrainian or Russian project name no longer dead-ends on a validation error.
+
 ### Fixed
 
 - The Terminal tab rejected a Cron service session with "Service cron is not enabled" even when Cron was configured — its availability check checked every other addable service but never special-cased Cron the way service start/stop/exec already did.

--- a/src/features/project-wizard/components/steps/basics-step.tsx
+++ b/src/features/project-wizard/components/steps/basics-step.tsx
@@ -4,6 +4,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { pickLanguage } from "@/i18n"
+import { transliterateCyrillic } from "@/lib/slug"
 import type { Site } from "@/types"
 
 import { Field, Hint } from "../../form-fields"
@@ -43,7 +44,7 @@ export function BasicsStep({
             autoFocus
             value={name}
             onChange={(event) => {
-              const value = event.target.value
+              const value = transliterateCyrillic(event.target.value)
               setName(value)
               setDomain(`${value.toLowerCase().replace(/_/g, "-")}.localhost`)
             }}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,63 @@
+// Cyrillic → Latin transliteration for turning a typed project name into a
+// slug that's actually usable: it becomes the Docker container name prefix,
+// the `.localhost` domain label, and the project's directory name, all of
+// which must be ASCII. Rejecting Cyrillic input outright just moves the
+// failure somewhere far less clear (a raw Docker "invalid container name"
+// error deep into creation) instead of transliterating it into something
+// that works, the way most CMS "URL slug" fields handle a non-Latin title.
+// Ukrainian-leaning mapping (г→h, х→kh, ц→ts, ч→ch, ш→sh, щ→shch, ю→iu,
+// я→ia, є→ie, ї→i, й→i) with the handful of Russian-only letters covered
+// too, since nothing here validates which Cyrillic alphabet was used.
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+  а: "a",
+  б: "b",
+  в: "v",
+  г: "h",
+  ґ: "g",
+  д: "d",
+  е: "e",
+  є: "ie",
+  ж: "zh",
+  з: "z",
+  и: "y",
+  і: "i",
+  ї: "i",
+  й: "i",
+  к: "k",
+  л: "l",
+  м: "m",
+  н: "n",
+  о: "o",
+  п: "p",
+  р: "r",
+  с: "s",
+  т: "t",
+  у: "u",
+  ф: "f",
+  х: "kh",
+  ц: "ts",
+  ч: "ch",
+  ш: "sh",
+  щ: "shch",
+  ъ: "",
+  ы: "y",
+  ь: "",
+  э: "e",
+  ю: "iu",
+  я: "ia",
+  ё: "e",
+}
+
+/** Transliterates any Cyrillic characters in `value` to Latin; every other
+ * character (including ones the caller's own validation will still reject)
+ * passes through unchanged. */
+export function transliterateCyrillic(value: string): string {
+  return Array.from(value)
+    .map((character) => {
+      const lower = character.toLowerCase()
+      const mapped = CYRILLIC_TO_LATIN[lower]
+      if (mapped === undefined) return character
+      return character === lower ? mapped : mapped.charAt(0).toUpperCase() + mapped.slice(1)
+    })
+    .join("")
+}

--- a/tests/slug.test.ts
+++ b/tests/slug.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { transliterateCyrillic } from "../src/lib/slug.ts"
+
+test("transliterates Ukrainian Cyrillic into an ASCII-safe slug", () => {
+  assert.equal(transliterateCyrillic("Мій проєкт"), "Mii proiekt")
+  assert.equal(transliterateCyrillic("щастя"), "shchastia")
+  assert.equal(transliterateCyrillic("гроші"), "hroshi")
+})
+
+test("leaves already-ASCII input untouched", () => {
+  assert.equal(transliterateCyrillic("my-project_2"), "my-project_2")
+})
+
+test("passes through characters it doesn't recognize instead of dropping them", () => {
+  assert.equal(transliterateCyrillic("プロジェクト"), "プロジェクト")
+})


### PR DESCRIPTION
## Summary
Reported by the user with a screenshot: typing a Cyrillic project name in the wizard's Basics step showed both the Name and Local domain fields red ("Letters, digits, hyphens and underscores." / "Must end in .localhost.") with no way to actually create a project with a Ukrainian/Russian name.

Traced why this validation exists before touching it — it's not arbitrary. `site.name`/`environment.name` become, directly:
- The Docker container name prefix (`container_compose.rs`: `web_container_name` defaults to `format!("{}-web", e.name)`), and Docker container names must match `[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
- The `.localhost` domain label (DNS labels are ASCII-only without IDNA/punycode, which nothing here implements).
- The project's directory name.

So accepting raw Cyrillic would just move the failure to a much less clear place — a raw Docker "invalid container name" error partway through creation, or worse, after some resources already exist — which cuts against this app's own "visible automation, clear reason for failure" principle.

Fix: transliterate Cyrillic to Latin live in the Name field's `onChange`, the same pattern CMS/e-commerce "URL slug" fields use for a non-Latin title (`src/lib/slug.ts`, Ukrainian-leaning mapping since the app's other locale is `uk`). The field shows exactly what will actually be used — no hidden mismatch between what you typed and what got created.

## Test plan
- [x] Added `tests/slug.test.ts` (3 cases: real Ukrainian words including the multi-letter digraphs щ/ю/я/є, already-ASCII passthrough, and non-Cyrillic non-ASCII passthrough since only Cyrillic is transliterated).
- [x] `prettier --check`, `eslint`, `tsc --noEmit`, `test:frontend` (11/11) all pass